### PR TITLE
fixed scripting agent/tile

### DIFF
--- a/nmmo/scripting.py
+++ b/nmmo/scripting.py
@@ -39,12 +39,13 @@ class Observation:
       Returns:
          Vector corresponding to the specified tile
       '''
-      return self.tiles[self.config.PLAYER_VISION_DIAMETER * (self.delta + rDelta) + self.delta + cDelta]
+      return self.tiles[self.config.PLAYER_VISION_DIAMETER * (self.delta + cDelta) + self.delta + rDelta]
 
    @property
    def agent(self):
       '''Return the array object corresponding to the current agent'''
-      return self.agents[0]
+      curr_idx = (self.config.PLAYER_VISION_DIAMETER + 1) * self.delta
+      return self.obs['Entity']['Continuous'][curr_idx]
 
    @staticmethod
    def attribute(ary, attr):

--- a/tests/test_scripting_obs.py
+++ b/tests/test_scripting_obs.py
@@ -1,0 +1,62 @@
+from pdb import set_trace as T
+import unittest
+from tqdm import tqdm
+
+import nmmo
+from scripted import baselines
+
+TEST_HORIZON = 5
+
+
+class Config(nmmo.config.Small, nmmo.config.AllGameSystems):
+
+    RENDER = False
+    SPECIALIZE = True
+    PLAYERS = [
+            baselines.Fisher, baselines.Herbalist, baselines.Prospector, baselines.Carver, baselines.Alchemist,
+            baselines.Melee, baselines.Range, baselines.Mage]
+
+
+class TestScriptingObservation(unittest.TestCase):
+   @classmethod
+   def setUpClass(cls):
+      cls.config = Config()
+      cls.env = nmmo.Env(cls.config)
+      cls.env.reset()
+
+      print('Running', TEST_HORIZON, 'tikcs')
+      for t in tqdm(range(TEST_HORIZON)):
+         cls.env.step({})
+
+      cls.obs, _ = cls.env.realm.dataframe.get(cls.env.realm.players)
+
+   def test_observation_agent(self):
+      for playerID in self.obs.keys():
+         ob = nmmo.scripting.Observation(self.config, self.obs[playerID])
+         agent = ob.agent
+
+         # player's entID must match
+         self.assertEqual(playerID, nmmo.scripting.Observation.attribute(agent, nmmo.Serialized.Entity.ID))
+
+   def test_observation_tile(self):
+      vision = self.config.PLAYER_VISION_RADIUS
+
+      for playerID in self.obs.keys():
+         ob = nmmo.scripting.Observation(self.config, self.obs[playerID])
+         agent = ob.agent
+
+         # the current player's location
+         r_cent = nmmo.scripting.Observation.attribute(agent, nmmo.Serialized.Entity.R)
+         c_cent = nmmo.scripting.Observation.attribute(agent, nmmo.Serialized.Entity.C)
+
+         for r_delta in range(-vision, vision+1):
+            for c_delta in range(-vision, vision+1):
+               tile = ob.tile(r_delta, c_delta)
+
+               # tile's coordinate must match
+               self.assertEqual(r_cent + r_delta, nmmo.scripting.Observation.attribute(tile, nmmo.Serialized.Tile.R))
+               self.assertEqual(c_cent + c_delta, nmmo.scripting.Observation.attribute(tile, nmmo.Serialized.Tile.C))
+
+if __name__ == '__main__':
+   unittest.main()
+


### PR DESCRIPTION
In the new vec obs env, the scripted agents were jumping to lava and chose targets that were out of range. 

This was because the retrieved agent and tiles from nmmo.scripting.Observation, thus the coordinate information, were incorrect. 

This PR includes new tests for checking correctness of the retrieved agent and tile coordinates and fixes. 