### PR TITLE
quick fixes to pettingzoo AgentID and pre-commit pylint

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,6 @@
 name: Pylint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install .
     - name: Analysing the code with pylint
       run: |
         pylint --rcfile=pylint.cfg --recursive=y nmmo tests

--- a/scripts/git-pr.sh
+++ b/scripts/git-pr.sh
@@ -66,9 +66,12 @@ echo "Pushing topic branch to origin..."
 git push -u origin $branch_name
 
 # Generate a Github pull request
-echo "Generating Github pull request..."
-pull_request_url="https://github.com/CarperAI/nmmo-environment/compare/$MASTER_BRANCH...CarperAI:nmmo-environment:$branch_name?expand=1"
+read -p "Do you like to create a PR to the CarperAI/nmmo-environment repo? (y/n) " ans
+if [ "$ans" != "n" ]; then
+  echo "Generating Github pull request..."
+  pull_request_url="https://github.com/CarperAI/nmmo-environment/compare/$MASTER_BRANCH...CarperAI:nmmo-environment:$branch_name?expand=1"
 
-echo "Pull request URL: $pull_request_url"
+  echo "Pull request URL: $pull_request_url"
+if
 
 

--- a/scripts/git-pr.sh
+++ b/scripts/git-pr.sh
@@ -72,6 +72,4 @@ if [ "$ans" != "n" ]; then
   pull_request_url="https://github.com/CarperAI/nmmo-environment/compare/$MASTER_BRANCH...CarperAI:nmmo-environment:$branch_name?expand=1"
 
   echo "Pull request URL: $pull_request_url"
-if
-
-
+fi

--- a/scripts/git-pr.sh
+++ b/scripts/git-pr.sh
@@ -65,11 +65,8 @@ fi
 echo "Pushing topic branch to origin..."
 git push -u origin $branch_name
 
-# Generate a Github pull request
-read -p "Do you like to create a PR to the CarperAI/nmmo-environment repo? (y/n) " ans
-if [ "$ans" != "n" ]; then
-  echo "Generating Github pull request..."
-  pull_request_url="https://github.com/CarperAI/nmmo-environment/compare/$MASTER_BRANCH...CarperAI:nmmo-environment:$branch_name?expand=1"
+# Generate a Github pull request (just the url, not actually making a PR)
+echo "Generating Github pull request..."
+pull_request_url="https://github.com/CarperAI/nmmo-environment/compare/$MASTER_BRANCH...CarperAI:nmmo-environment:$branch_name?expand=1"
 
-  echo "Pull request URL: $pull_request_url"
-fi
+echo "Pull request URL: $pull_request_url"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from itertools import chain
 
 from setuptools import find_packages, setup
 
-
 REPO_URL = "https://github.com/neuralmmo/environment"
 
 extra = {

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ extra = {
     'cleanrl': [
         'wandb==0.12.9',
         'supersuit==3.3.5',
-        'gym==0.23.0',
         'tensorboard',
         'torch',
         'openskill',
@@ -31,7 +30,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'pytest-benchmark==3.4.1',
-        'openskill',
+        'openskill==4.0.0',
         'fire==0.4.0',
         'setproctitle==1.1.10',
         'service-identity==21.1.0',
@@ -42,10 +41,13 @@ setup(
         'tqdm==4.61.1',
         'lz4==4.0.0',
         'h5py==3.7.0',
-        'ordered-set',
+        'ordered-set==4.1.0',
         'pettingzoo==1.19.0',
-        'py',
-        'scipy'
+        'gym==0.23.0',
+        'pylint==2.16.0',
+        'py==1.11.0',
+        'scipy==1.10.0',
+        'numpy==1.24.1'
     ],
     extras_require=extra,
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'lz4==4.0.0',
         'h5py==3.7.0',
         'ordered-set',
-        'pettingzoo==1.15.0',
+        'pettingzoo==1.19.0',
         'py',
         'scipy'
     ],


### PR DESCRIPTION
1. bumped pettingzoo to 1.19.0, which doesn't mess with gym==0.23.0
2. moved gym to `install_requires` from `cleanrl` since nmmo core uses gym
3. pinned all package versions, except torch, tensorboard
4. during pre-commit checks, install all dependencies to make the checks work. (it seems that specifying `known-third-party=` in pylint.cfg doesn't fix this error)