### PR TITLE
synced realm.items and item datatable when destroying an item

### DIFF
--- a/nmmo/core/realm.py
+++ b/nmmo/core/realm.py
@@ -77,13 +77,15 @@ class Realm:
     # EntityState and ItemState tables must be empty after players/npcs.reset()
     self.players.reset()
     self.npcs.reset()
-    assert EntityState.State.table(self.datastore).is_empty(), \
-        "EntityState table is not empty"
+    #assert EntityState.State.table(self.datastore).is_empty(), \
+    #    "EntityState table is not empty"
+    EntityState.State.table(self.datastore).reset()
 
     # TODO(kywch): ItemState table is not empty after players/npcs.reset()
     #   but should be. Will fix this while debugging the item system.
     # assert ItemState.State.table(self.datastore).is_empty(), \
     #     "ItemState table is not empty"
+    ItemState.State.table(self.datastore).reset()
 
     self.players.spawn()
     self.npcs.spawn()

--- a/nmmo/core/realm.py
+++ b/nmmo/core/realm.py
@@ -77,9 +77,8 @@ class Realm:
     # EntityState and ItemState tables must be empty after players/npcs.reset()
     self.players.reset()
     self.npcs.reset()
-    #assert EntityState.State.table(self.datastore).is_empty(), \
-    #    "EntityState table is not empty"
-    EntityState.State.table(self.datastore).reset()
+    assert EntityState.State.table(self.datastore).is_empty(), \
+        "EntityState table is not empty"
 
     # TODO(kywch): ItemState table is not empty after players/npcs.reset()
     #   but should be. Will fix this while debugging the item system.

--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -292,7 +292,7 @@ class Entity(EntityState):
     if source is None or not source.is_player: # nobody or npcs cannot loot
       if self.config.ITEM_SYSTEM_ENABLED:
         for item in list(self.inventory.items):
-          item.datastore_record.delete()
+          item.destroy()
       return True
 
     # now, source can loot the dead self

--- a/nmmo/systems/inventory.py
+++ b/nmmo/systems/inventory.py
@@ -185,7 +185,6 @@ class Inventory:
 
     self._remove(item)
 
-  # pylint: disable=protected-access
   def _remove(self, item):
     self.realm.exchange.unlist_item(item)
     item.owner_id.update(0)

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -92,9 +92,9 @@ class TestAmmoUse(unittest.TestCase):
     # check if the ammos were consumed
     ammo_ids = []
     for ent_id in self.ammo:
-      self.assertEqual(1, # True
-        ItemState.parse_array(env.obs[ent_id].inventory.values[0]).quantity)
-      ammo_ids.append(ItemState.parse_array(env.obs[ent_id].inventory.values[0]).id)
+      item_info = ItemState.parse_array(env.obs[ent_id].inventory.values[0])
+      self.assertEqual(1, item_info.quantity)
+      ammo_ids.append(item_info.id)
 
     # Third tick actions: ATTACK again to use up all the ammo
     env.step({ ent_id: { action.Attack: 

--- a/tests/core/test_env.py
+++ b/tests/core/test_env.py
@@ -136,6 +136,13 @@ class TestEnv(unittest.TestCase):
       new_env.step({})
     new_env.reset()
 
+    # items are referenced in the realm.items, which must be empty
+    self.assertTrue(len(new_env.realm.items) == 0)
+
+    # items are referenced in the exchange
+    self.assertTrue(len(new_env.realm.exchange._item_listings) == 0)
+    self.assertTrue(len(new_env.realm.exchange._listings_queue) == 0)
+
     # TODO(kywch): ItemState table is not empty after players/npcs.reset()
     #   but should be. Will fix this while debugging the item system.
     # So for now, ItemState table is cleared manually here, just to pass this test 

--- a/tests/systems/test_item.py
+++ b/tests/systems/test_item.py
@@ -16,15 +16,25 @@ class TestItem(unittest.TestCase):
     realm = MockRealm()
 
     hat_1 = Hat(realm, 1)
+    self.assertTrue(ItemState.Query.by_id(realm.datastore, hat_1.id.val) is not None)
     self.assertEqual(hat_1.type_id.val, Hat.ITEM_TYPE_ID)
     self.assertEqual(hat_1.level.val, 1)
     self.assertEqual(hat_1.mage_defense.val, 10)
 
     hat_2 = Hat(realm, 10)
+    self.assertTrue(ItemState.Query.by_id(realm.datastore, hat_2.id.val) is not None)
     self.assertEqual(hat_2.level.val, 10)
     self.assertEqual(hat_2.melee_defense.val, 100)
 
     self.assertDictEqual(realm.items, {hat_1.id.val: hat_1, hat_2.id.val: hat_2})
+
+    # also test destroy
+    ids = [hat_1.id.val, hat_2.id.val]
+    hat_1.destroy()
+    hat_2.destroy()
+    for item_id in ids:
+      self.assertTrue(len(ItemState.Query.by_id(realm.datastore, item_id)) == 0)
+    self.assertDictEqual(realm.items, {})
 
   def test_owned_by(self):
     realm = MockRealm()


### PR DESCRIPTION
Problem: 
1. we are still leaking entities/items between resets in the data table.
2. we sometimes buy items with 0 quantity
3. we sometimes buy items that are listed but not in seller's inventory

This at least syncs realm.items and item data table so that env._process_actions() can drop invalid buy command with deleted items. 

I'll keep debugging buy-sell actions