### PR TITLE
ActionTargets implementation (WIP)

### DIFF
--- a/nmmo/core/config.py
+++ b/nmmo/core/config.py
@@ -521,6 +521,9 @@ class Item:
   ITEM_INVENTORY_CAPACITY             = 12
   '''Number of inventory spaces'''
 
+  ITEM_GIVE_TO_FRIENDLY               = True
+  '''Whether agents with the same population index can give gold/item to each other'''
+
   @property
   def INVENTORY_N_OBS(self):
     '''Number of distinct item observations'''

--- a/nmmo/core/config.py
+++ b/nmmo/core/config.py
@@ -202,6 +202,7 @@ class Config(Template):
   PLAYER_N                     = None
   '''Maximum number of players spawnable in the environment'''
 
+  # TODO(kywch): CHECK if there could be 100+ entities within one's vision
   PLAYER_N_OBS                 = 100
   '''Number of distinct agent observations'''
 
@@ -521,12 +522,10 @@ class Item:
   '''Number of inventory spaces'''
 
   @property
-  def ITEM_N_OBS(self):
+  def INVENTORY_N_OBS(self):
     '''Number of distinct item observations'''
-    # TODO: This is a hack, referring to NPC_LEVEL_MAX not defined here
-    # pylint: disable=no-member
-    return self.ITEM_N * self.NPC_LEVEL_MAX
-    #return self.INVENTORY_CAPACITY
+    return self.ITEM_INVENTORY_CAPACITY
+
 
 
 class Equipment:
@@ -613,11 +612,12 @@ class Exchange:
   EXCHANGE_LISTING_DURATION           = 5
 
   @property
-  def EXCHANGE_N_OBS(self):
-    # TODO: This is a hack, referring to NPC_LEVEL_MAX not defined here
+  def MARKET_N_OBS(self):
+    # TODO(kywch): This is a hack. Check if the limit is reached
     # pylint: disable=no-member
     '''Number of distinct item observations'''
-    return self.ITEM_N * self.NPC_LEVEL_MAX
+    return self.PLAYER_N * self.EXCHANGE_LISTING_DURATION
+
 
 class Communication:
   '''Exchange Game System'''
@@ -625,12 +625,9 @@ class Communication:
   COMMUNICATION_SYSTEM_ENABLED             = True
   '''Game system flag'''
 
-  @property
-  def COMMUNICATION_NUM_TOKENS(self):
-    '''Number of distinct item observations'''
-    # TODO: This is a hack, referring to NPC_LEVEL_MAX not defined here
-    # pylint: disable=no-member
-    return self.ITEM_N * self.NPC_LEVEL_MAX
+  # CHECK ME: When do we actually use this?
+  COMMUNICATION_NUM_TOKENS                 = 50
+  '''Number of distinct COMM tokens'''
 
 
 class AllGameSystems(

--- a/nmmo/core/env.py
+++ b/nmmo/core/env.py
@@ -35,12 +35,11 @@ class Env(ParallelEnv):
     self.obs = None
 
     self.possible_agents = list(range(1, config.PLAYER_N + 1))
-    self._dead_agents = set()
+    self._dead_agents = OrderedSet()
     self.scripted_agents = OrderedSet()
 
   # pylint: disable=method-cache-max-size-none
   @functools.lru_cache(maxsize=None)
-  # CHECK ME: Do we need the agent parameter here?
   def observation_space(self, agent: int):
     '''Neural MMO Observation Space
 
@@ -79,7 +78,6 @@ class Env(ParallelEnv):
       random.seed(seed)
 
   @functools.lru_cache(maxsize=None)
-  # CHECK ME: Do we need the agent parameter here?
   def action_space(self, agent):
     '''Neural MMO Action Space
 
@@ -133,7 +131,7 @@ class Env(ParallelEnv):
 
     self._init_random(seed)
     self.realm.reset(map_id)
-    self._dead_agents = set()
+    self._dead_agents = OrderedSet()
 
     # check if there are scripted agents
     for eid, ent in self.realm.players.items():

--- a/nmmo/core/env.py
+++ b/nmmo/core/env.py
@@ -39,6 +39,7 @@ class Env(ParallelEnv):
 
   # pylint: disable=method-cache-max-size-none
   @functools.lru_cache(maxsize=None)
+  # CHECK ME: Do we need the agent parameter here?
   def observation_space(self, agent: int):
     '''Neural MMO Observation Space
 
@@ -64,10 +65,10 @@ class Env(ParallelEnv):
     }
 
     if self.config.ITEM_SYSTEM_ENABLED:
-      obs_space["Item"] = box(self.config.ITEM_N_OBS, Item.State.num_attributes)
+      obs_space["Inventory"] = box(self.config.INVENTORY_N_OBS, Item.State.num_attributes)
 
     if self.config.EXCHANGE_SYSTEM_ENABLED:
-      obs_space["Market"] = box(self.config.EXCHANGE_N_OBS, Item.State.num_attributes)
+      obs_space["Market"] = box(self.config.MARKET_N_OBS, Item.State.num_attributes)
 
     return gym.spaces.Dict(obs_space)
 
@@ -77,6 +78,7 @@ class Env(ParallelEnv):
       random.seed(seed)
 
   @functools.lru_cache(maxsize=None)
+  # CHECK ME: Do we need the agent parameter here?
   def action_space(self, agent):
     '''Neural MMO Action Space
 
@@ -291,7 +293,7 @@ class Env(ParallelEnv):
               break
 
           elif atn in (nmmo.action.Sell, nmmo.action.Use, nmmo.action.Give) \
-            and arg == nmmo.action.Item:
+            and arg == nmmo.action.InventoryItem:
 
             item_id = entity_obs.inventory.id(val)
             item = self.realm.items.get(item_id)
@@ -302,7 +304,7 @@ class Env(ParallelEnv):
               action_valid = False
               break
 
-          elif atn == nmmo.action.Buy and arg == nmmo.action.Item:
+          elif atn == nmmo.action.Buy and arg == nmmo.action.MarketItem:
             item_id = entity_obs.market.id(val)
             item = self.realm.items.get(item_id)
             if item is not None:

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -1,5 +1,4 @@
 from functools import lru_cache
-from types import SimpleNamespace
 
 import numpy as np
 
@@ -8,7 +7,37 @@ from nmmo.entity.entity import EntityState
 from nmmo.systems.item import ItemState
 import nmmo.systems.item as item_system
 from nmmo.io import action
-from nmmo.lib import material
+from nmmo.lib import material, utils
+
+
+class BasicObs:
+  def __init__(self, values, id_col):
+    self.values = values
+    self.ids = values[:, id_col]
+
+  @property
+  def len(self):
+    return len(self.ids)
+
+  def id(self, i):
+    return self.ids[i] if i < self.len else None
+
+  def index(self, val):
+    return np.nonzero(self.ids == val)[0][0] if val in self.ids else None
+
+
+class InventoryObs(BasicObs):
+  def __init__(self, values, id_col):
+    super().__init__(values, id_col)
+    self.inv_type = self.values[:,ItemState.State.attr_name_to_col["type_id"]]
+    self.inv_level = self.values[:,ItemState.State.attr_name_to_col["level"]]
+
+  def sig(self, itm_type, level):
+    if (itm_type in self.inv_type) and (level in self.inv_level):
+      return np.nonzero((self.inv_type == itm_type) & (self.inv_level == level))[0][0]
+
+    return None
+
 
 class Observation:
   def __init__(self,
@@ -23,50 +52,18 @@ class Observation:
     self.agent_id = agent_id
 
     self.tiles = tiles[0:config.MAP_N_OBS]
-
-    entities = entities[0:config.PLAYER_N_OBS]
-    entity_ids = entities[:,EntityState.State.attr_name_to_col["id"]]
-    entity_pos = entities[:,[EntityState.State.attr_name_to_col["row"],
-                             EntityState.State.attr_name_to_col["col"]]]
-    self.entities = SimpleNamespace(
-        values = entities,
-        ids = entity_ids,
-        len = len(entity_ids),
-        id = lambda i: entity_ids[i] if i < len(entity_ids) else None,
-        index = lambda val: np.nonzero(entity_ids == val)[0][0] if val in entity_ids else None,
-        pos = entity_pos,
-        # for the distance function, see io/action.py, Attack.call(), line 222
-        dist = lambda pos: np.max(np.abs(entity_pos - np.array(pos)), axis=1),
-    )
+    self.entities = BasicObs(entities[0:config.PLAYER_N_OBS],
+                              EntityState.State.attr_name_to_col["id"])
 
     if config.ITEM_SYSTEM_ENABLED:
-      inventory = inventory[0:config.INVENTORY_N_OBS]
-      inv_ids = inventory[:,ItemState.State.attr_name_to_col["id"]]
-      inv_type = inventory[:,ItemState.State.attr_name_to_col["type_id"]]
-      inv_level = inventory[:,ItemState.State.attr_name_to_col["level"]]
-      self.inventory = SimpleNamespace(
-        values = inventory,
-        ids = inv_ids,
-        len = len(inv_ids),
-        id = lambda i: inv_ids[i] if i < len(inv_ids) else None,
-        index = lambda val: np.nonzero(inv_ids == val)[0][0] if val in inv_ids else None,
-        sig = lambda itm_type, level:
-                np.nonzero((inv_type == itm_type) & (inv_level == level))[0][0]
-                if (itm_type in inv_type) and (level in inv_level) else None
-      )
+      self.inventory = InventoryObs(inventory[0:config.INVENTORY_N_OBS],
+                                    ItemState.State.attr_name_to_col["id"])
     else:
       assert inventory.size == 0
 
     if config.EXCHANGE_SYSTEM_ENABLED:
-      market = market[0:config.MARKET_N_OBS]
-      market_ids = market[:,ItemState.State.attr_name_to_col["id"]]
-      self.market = SimpleNamespace(
-        values = market,
-        ids = market_ids,
-        len = len(market_ids),
-        id = lambda i: market_ids[i] if i < len(market_ids) else None,
-        index = lambda val: np.nonzero(market_ids == val)[0][0] if val in market_ids else None
-      )
+      self.market = BasicObs(market[0:config.MARKET_N_OBS],
+                             ItemState.State.attr_name_to_col["id"])
     else:
       assert market.size == 0
 
@@ -129,99 +126,101 @@ class Observation:
           self.market.values.shape[1]))
       ])
 
-    gym_obs["ActionTargets"] = self.generate_action_targets()
+    gym_obs["ActionTargets"] = self._make_action_targets()
 
     return gym_obs
 
-  def generate_action_targets(self):
+  def _make_action_targets(self):
     # TODO(kywch): return all-0 masks for buy/sell/give during combat
 
     masks = {}
     masks[action.Move] = {
-      action.Direction: self._generate_move_mask()
+      action.Direction: self._make_move_mask()
     }
 
     if self.config.COMBAT_SYSTEM_ENABLED:
       masks[action.Attack] = {
-        action.Style: self._generate_allow_all_mask(action.Style.edges),
-        action.Target: self._generate_attack_mask()
+        action.Style: self._make_allow_all_mask(action.Style.edges),
+        action.Target: self._make_attack_mask()
       }
 
     if self.config.ITEM_SYSTEM_ENABLED:
       masks[action.Use] = {
-        action.InventoryItem: self._generate_use_mask()
+        action.InventoryItem: self._make_use_mask()
       }
 
     if self.config.EXCHANGE_SYSTEM_ENABLED:
       masks[action.Sell] = {
-        action.InventoryItem: self._generate_sell_mask(),
+        action.InventoryItem: self._make_sell_mask(),
         action.Price: None # allow any integer
       }
       masks[action.Buy] = {
-        action.MarketItem: self._generate_buy_mask()
+        action.MarketItem: self._make_buy_mask()
       }
 
     if self.config.COMMUNICATION_SYSTEM_ENABLED:
       masks[action.Comm] = {
-        action.Token: self._generate_allow_all_mask(action.Token.edges),
+        action.Token: self._make_allow_all_mask(action.Token.edges),
       }
 
     return masks
 
-  def _generate_allow_all_mask(self, actions):
+  def _make_allow_all_mask(self, actions):
     return np.ones(len(actions), dtype=np.int8)
 
-  def _generate_move_mask(self):
+  def _make_move_mask(self):
     # pylint: disable=not-an-iterable
     return np.array(
       [self.tile(*d.delta).material_id in material.Habitable
        for d in action.Direction.edges], dtype=np.int8)
 
-  def _generate_attack_mask(self):
+  def _make_attack_mask(self):
     # TODO: Currently, all attacks have the same range
     #   if we choose to make ranges different, the masks
     #   should be differently generated by attack styles
     assert self.config.COMBAT_MELEE_REACH == self.config.COMBAT_RANGE_REACH
     assert self.config.COMBAT_MELEE_REACH == self.config.COMBAT_MAGE_REACH
-    assert self.config.COMBAT_RANGE_REACH == self.config.COMBAT_RANGE_REACH
+    assert self.config.COMBAT_RANGE_REACH == self.config.COMBAT_MAGE_REACH
 
     attack_range = self.config.COMBAT_MELEE_REACH
 
     agent = self.agent()
-    dist_from_self = self.entities.dist((agent.row, agent.col))
-    not_same_tile = dist_from_self > 0 # this also includes not_self
-    within_range = dist_from_self <= attack_range
+    entities_pos = self.entities.values[:, [EntityState.State.attr_name_to_col["row"],
+                                            EntityState.State.attr_name_to_col["col"]]]
+    within_range = utils.linf(entities_pos, (agent.row, agent.col)) <= attack_range
 
     if not self.config.COMBAT_FRIENDLY_FIRE:
       population = self.entities.values[:,EntityState.State.attr_name_to_col["population_id"]]
-      no_friendly_fire = population != agent.population_id
+      no_friendly_fire = population != agent.population_id # this automatically masks self
     else:
-      # allow friendly fire
+      # allow friendly fire but self
       no_friendly_fire = np.ones(self.entities.len, dtype=np.int8)
+      no_friendly_fire[self.entities.index(agent.id)] = 0 # mask self
 
-    return np.concatenate([not_same_tile & within_range & no_friendly_fire,
+    return np.concatenate([within_range & no_friendly_fire,
       np.zeros(self.config.PLAYER_N_OBS - self.entities.len, dtype=np.int8)])
 
-  def _generate_use_mask(self):
+  def _make_use_mask(self):
     # empty inventory -- nothing to use
     if self.inventory.len == 0:
       return np.zeros(self.config.INVENTORY_N_OBS, dtype=np.int8)
+
+    item_skill = self._item_skill()
 
     not_listed = self.inventory.values[:,ItemState.State.attr_name_to_col["listed_price"]] == 0
     item_type = self.inventory.values[:,ItemState.State.attr_name_to_col["type_id"]]
     item_level = self.inventory.values[:,ItemState.State.attr_name_to_col["level"]]
 
     # level limits are differently applied depending on item types
-    type_flt = np.tile ( np.array(list(self._item_skill.keys())), (self.inventory.len,1) )
-    level_flt = np.tile ( np.array(list(self._item_skill.values())), (self.inventory.len,1) )
-    item_type = np.tile( np.transpose(np.atleast_2d(item_type)), (1, len(self._item_skill)))
-    item_level = np.tile( np.transpose(np.atleast_2d(item_level)), (1, len(self._item_skill)))
+    type_flt = np.tile ( np.array(list(item_skill.keys())), (self.inventory.len,1) )
+    level_flt = np.tile ( np.array(list(item_skill.values())), (self.inventory.len,1) )
+    item_type = np.tile( np.transpose(np.atleast_2d(item_type)), (1, len(item_skill)))
+    item_level = np.tile( np.transpose(np.atleast_2d(item_level)), (1, len(item_skill)))
     level_satisfied = np.any((item_type == type_flt) & (item_level <= level_flt), axis=1)
 
     return np.concatenate([not_listed & level_satisfied,
       np.zeros(self.config.INVENTORY_N_OBS - self.inventory.len, dtype=np.int8)])
 
-  @property
   def _item_skill(self):
     agent = self.agent()
 
@@ -248,7 +247,7 @@ class Observation:
       item_system.Poultice.ITEM_TYPE_ID: level
     }
 
-  def _generate_sell_mask(self):
+  def _make_sell_mask(self):
     # empty inventory -- nothing to sell
     if self.inventory.len == 0:
       return np.zeros(self.config.INVENTORY_N_OBS, dtype=np.int8)
@@ -259,7 +258,7 @@ class Observation:
     return np.concatenate([not_equipped & not_listed,
       np.zeros(self.config.INVENTORY_N_OBS - self.inventory.len, dtype=np.int8)])
 
-  def _generate_buy_mask(self):
+  def _make_buy_mask(self):
     market_flt = np.ones(self.market.len, dtype=np.int8)
     full_inventory = self.inventory.len >= self.config.ITEM_INVENTORY_CAPACITY
 

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -6,7 +6,9 @@ import numpy as np
 from nmmo.core.tile import TileState
 from nmmo.entity.entity import EntityState
 from nmmo.systems.item import ItemState
-
+import nmmo.systems.item as item_system
+from nmmo.io import action
+from nmmo.lib import material
 
 class Observation:
   def __init__(self,
@@ -24,30 +26,46 @@ class Observation:
 
     entities = entities[0:config.PLAYER_N_OBS]
     entity_ids = entities[:,EntityState.State.attr_name_to_col["id"]]
+    entity_pos = entities[:,[EntityState.State.attr_name_to_col["row"],
+                             EntityState.State.attr_name_to_col["col"]]]
     self.entities = SimpleNamespace(
         values = entities,
         ids = entity_ids,
-        id = lambda i: entity_ids[i] if i < len(entity_ids) else None
+        len = len(entity_ids),
+        id = lambda i: entity_ids[i] if i < len(entity_ids) else None,
+        index = lambda val: np.nonzero(entity_ids == val)[0][0] if val in entity_ids else None,
+        pos = entity_pos,
+        # for the distance function, see io/action.py, Attack.call(), line 222
+        dist = lambda pos: np.max(np.abs(entity_pos - np.array(pos)), axis=1),
     )
 
     if config.ITEM_SYSTEM_ENABLED:
-      inventory = inventory[0:config.ITEM_N_OBS]
+      inventory = inventory[0:config.INVENTORY_N_OBS]
       inv_ids = inventory[:,ItemState.State.attr_name_to_col["id"]]
+      inv_type = inventory[:,ItemState.State.attr_name_to_col["type_id"]]
+      inv_level = inventory[:,ItemState.State.attr_name_to_col["level"]]
       self.inventory = SimpleNamespace(
         values = inventory,
         ids = inv_ids,
-        id = lambda i: inv_ids[i] if i < len(inv_ids) else None
-    )
+        len = len(inv_ids),
+        id = lambda i: inv_ids[i] if i < len(inv_ids) else None,
+        index = lambda val: np.nonzero(inv_ids == val)[0][0] if val in inv_ids else None,
+        sig = lambda itm_type, level:
+                np.nonzero((inv_type == itm_type) & (inv_level == level))[0][0]
+                if (itm_type in inv_type) and (level in inv_level) else None
+      )
     else:
       assert inventory.size == 0
 
     if config.EXCHANGE_SYSTEM_ENABLED:
-      market = market[0:config.EXCHANGE_N_OBS]
+      market = market[0:config.MARKET_N_OBS]
       market_ids = market[:,ItemState.State.attr_name_to_col["id"]]
       self.market = SimpleNamespace(
         values = market,
         ids = market_ids,
-        id = lambda i: market_ids[i] if i < len(market_ids) else None
+        len = len(market_ids),
+        id = lambda i: market_ids[i] if i < len(market_ids) else None,
+        index = lambda val: np.nonzero(market_ids == val)[0][0] if val in market_ids else None
       )
     else:
       assert market.size == 0
@@ -100,15 +118,193 @@ class Observation:
     if self.config.ITEM_SYSTEM_ENABLED:
       gym_obs["Inventory"] = np.vstack([
         self.inventory.values, np.zeros((
-          self.config.ITEM_N_OBS - self.inventory.values.shape[0],
+          self.config.INVENTORY_N_OBS - self.inventory.values.shape[0],
           self.inventory.values.shape[1]))
       ])
 
     if self.config.EXCHANGE_SYSTEM_ENABLED:
       gym_obs["Market"] = np.vstack([
         self.market.values, np.zeros((
-          self.config.EXCHANGE_N_OBS - self.market.values.shape[0],
+          self.config.MARKET_N_OBS - self.market.values.shape[0],
           self.market.values.shape[1]))
       ])
 
+    gym_obs["ActionTargets"] = self.generate_action_targets()
+
     return gym_obs
+
+  def generate_action_targets(self):
+    # TODO(kywch): return all-0 masks for buy/sell/give during combat
+
+    masks = {}
+    masks[action.Move] = {
+      action.Direction: self._generate_move_mask()
+    }
+
+    if self.config.COMBAT_SYSTEM_ENABLED:
+      masks[action.Attack] = {
+        action.Style: self._generate_allow_all_mask(action.Style.edges),
+        action.Target: self._generate_attack_mask()
+      }
+
+    if self.config.ITEM_SYSTEM_ENABLED:
+      masks[action.Use] = {
+        action.InventoryItem: self._generate_use_mask()
+      }
+
+    if self.config.EXCHANGE_SYSTEM_ENABLED:
+      masks[action.Sell] = {
+        action.InventoryItem: self._generate_sell_mask(),
+        action.Price: None # allow any integer
+      }
+      masks[action.Buy] = {
+        action.MarketItem: self._generate_buy_mask()
+      }
+
+    if self.config.COMMUNICATION_SYSTEM_ENABLED:
+      masks[action.Comm] = {
+        action.Token: self._generate_allow_all_mask(action.Token.edges),
+      }
+
+    return masks
+
+  def _generate_allow_all_mask(self, actions):
+    return np.ones(len(actions), dtype=np.int8)
+
+  def _generate_move_mask(self):
+    # pylint: disable=not-an-iterable
+    return np.array(
+      [self.tile(*d.delta).material_id in material.Habitable
+       for d in action.Direction.edges], dtype=np.int8)
+
+  def _generate_attack_mask(self):
+    # TODO: Currently, all attacks have the same range
+    #   if we choose to make ranges different, the masks
+    #   should be differently generated by attack styles
+    assert self.config.COMBAT_MELEE_REACH == self.config.COMBAT_RANGE_REACH
+    assert self.config.COMBAT_MELEE_REACH == self.config.COMBAT_MAGE_REACH
+    assert self.config.COMBAT_RANGE_REACH == self.config.COMBAT_RANGE_REACH
+
+    attack_range = self.config.COMBAT_MELEE_REACH
+
+    agent = self.agent()
+    dist_from_self = self.entities.dist((agent.row, agent.col))
+    not_same_tile = dist_from_self > 0 # this also includes not_self
+    within_range = dist_from_self <= attack_range
+
+    if not self.config.COMBAT_FRIENDLY_FIRE:
+      population = self.entities.values[:,EntityState.State.attr_name_to_col["population_id"]]
+      no_friendly_fire = population != agent.population_id
+    else:
+      # allow friendly fire
+      no_friendly_fire = np.ones(self.entities.len, dtype=np.int8)
+
+    return np.concatenate([not_same_tile & within_range & no_friendly_fire,
+      np.zeros(self.config.PLAYER_N_OBS - self.entities.len, dtype=np.int8)])
+
+  def _generate_use_mask(self):
+    # empty inventory -- nothing to use
+    if self.inventory.len == 0:
+      return np.zeros(self.config.INVENTORY_N_OBS, dtype=np.int8)
+
+    not_listed = self.inventory.values[:,ItemState.State.attr_name_to_col["listed_price"]] == 0
+    item_type = self.inventory.values[:,ItemState.State.attr_name_to_col["type_id"]]
+    item_level = self.inventory.values[:,ItemState.State.attr_name_to_col["level"]]
+
+    # level limits are differently applied depending on item types
+    type_flt = np.tile ( np.array(list(self._item_skill.keys())), (self.inventory.len,1) )
+    level_flt = np.tile ( np.array(list(self._item_skill.values())), (self.inventory.len,1) )
+    item_type = np.tile( np.transpose(np.atleast_2d(item_type)), (1, len(self._item_skill)))
+    item_level = np.tile( np.transpose(np.atleast_2d(item_level)), (1, len(self._item_skill)))
+    level_satisfied = np.any((item_type == type_flt) & (item_level <= level_flt), axis=1)
+
+    return np.concatenate([not_listed & level_satisfied,
+      np.zeros(self.config.INVENTORY_N_OBS - self.inventory.len, dtype=np.int8)])
+
+  @property
+  def _item_skill(self):
+    agent = self.agent()
+
+    # the minimum agent level is 1
+    level = max(1, agent.melee_level, agent.range_level, agent.mage_level,
+                agent.fishing_level, agent.herbalism_level, agent.prospecting_level,
+                agent.carving_level, agent.alchemy_level)
+    return {
+      item_system.Hat.ITEM_TYPE_ID: level,
+      item_system.Top.ITEM_TYPE_ID: level,
+      item_system.Bottom.ITEM_TYPE_ID: level,
+      item_system.Sword.ITEM_TYPE_ID: agent.melee_level,
+      item_system.Bow.ITEM_TYPE_ID: agent.range_level,
+      item_system.Wand.ITEM_TYPE_ID: agent.mage_level,
+      item_system.Rod.ITEM_TYPE_ID: agent.fishing_level,
+      item_system.Gloves.ITEM_TYPE_ID: agent.herbalism_level,
+      item_system.Pickaxe.ITEM_TYPE_ID: agent.prospecting_level,
+      item_system.Chisel.ITEM_TYPE_ID: agent.carving_level,
+      item_system.Arcane.ITEM_TYPE_ID: agent.alchemy_level,
+      item_system.Scrap.ITEM_TYPE_ID: agent.melee_level,
+      item_system.Shaving.ITEM_TYPE_ID: agent.range_level,
+      item_system.Shard.ITEM_TYPE_ID: agent.mage_level,
+      item_system.Ration.ITEM_TYPE_ID: level,
+      item_system.Poultice.ITEM_TYPE_ID: level
+    }
+
+  def _generate_sell_mask(self):
+    # empty inventory -- nothing to sell
+    if self.inventory.len == 0:
+      return np.zeros(self.config.INVENTORY_N_OBS, dtype=np.int8)
+
+    not_equipped = self.inventory.values[:,ItemState.State.attr_name_to_col["equipped"]] == 0
+    not_listed = self.inventory.values[:,ItemState.State.attr_name_to_col["listed_price"]] == 0
+
+    return np.concatenate([not_equipped & not_listed,
+      np.zeros(self.config.INVENTORY_N_OBS - self.inventory.len, dtype=np.int8)])
+
+  def _generate_buy_mask(self):
+    market_flt = np.ones(self.market.len, dtype=np.int8)
+    full_inventory = self.inventory.len >= self.config.ITEM_INVENTORY_CAPACITY
+
+    # if the inventory is full, one can only buy existing ammo stack
+    if full_inventory:
+      exist_ammo_listings = self._existing_ammo_listings()
+      if not np.any(exist_ammo_listings):
+        return np.zeros(self.config.MARKET_N_OBS, dtype=np.int8)
+      market_flt = exist_ammo_listings
+
+    agent = self.agent()
+    market_items = self.market.values
+    enough_gold = market_items[:,ItemState.State.attr_name_to_col["listed_price"]] <= agent.gold
+    not_mine = market_items[:,ItemState.State.attr_name_to_col["owner_id"]] != self.agent_id
+    not_equipped = market_items[:,ItemState.State.attr_name_to_col["equipped"]] == 0
+
+    return np.concatenate([market_flt & enough_gold & not_mine & not_equipped,
+      np.zeros(self.config.MARKET_N_OBS - self.market.len, dtype=np.int8)])
+
+  def _existing_ammo_listings(self):
+    sig_col = (ItemState.State.attr_name_to_col["type_id"],
+               ItemState.State.attr_name_to_col["level"])
+    ammo_id = [ammo.ITEM_TYPE_ID for ammo in
+              [item_system.Scrap, item_system.Shaving, item_system.Shard]]
+
+    # search ammo stack from the inventory
+    type_flt = np.tile( np.array(ammo_id), (self.inventory.len,1))
+    item_type = np.tile(
+      np.transpose(np.atleast_2d(self.inventory.values[:,sig_col[0]])),
+      (1, len(ammo_id)))
+    exist_ammo = self.inventory.values[np.any(item_type == type_flt, axis=1)]
+
+    # self does not have ammo
+    if exist_ammo.shape[0] == 0:
+      return np.zeros(self.market.len, dtype=np.int8)
+
+    # search the existing ammo stack from the market
+    type_flt = np.tile( np.array(exist_ammo[:,sig_col[0]]), (self.market.len,1))
+    level_flt = np.tile( np.array(exist_ammo[:,sig_col[1]]), (self.market.len,1))
+    item_type = np.tile( np.transpose(np.atleast_2d(self.market.values[:,sig_col[0]])),
+      (1, exist_ammo.shape[0]))
+    item_level = np.tile( np.transpose(np.atleast_2d(self.market.values[:,sig_col[1]])),
+      (1, exist_ammo.shape[0]))
+    exist_ammo_listings = np.any((item_type == type_flt) & (item_level == level_flt), axis=1)
+
+    not_mine = self.market.values[:,ItemState.State.attr_name_to_col["owner_id"]] != self.agent_id
+
+    return exist_ammo_listings & not_mine

--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -283,12 +283,16 @@ class Entity(EntityState):
     if self.alive:
       return True
 
-    # if the entity is dead, unlist its items regardless of looting
+    # at this point, self is dead
+    if source:
+      source.history.player_kills += 1
+
+    # if self is dead, unlist its items from the market regardless of looting
     if self.config.EXCHANGE_SYSTEM_ENABLED:
       for item in list(self.inventory.items):
         self.realm.exchange.unlist_item(item)
 
-    # if the entity is dead but no one can loot, destroy its items
+    # if self is dead but no one can loot, destroy its items
     if source is None or not source.is_player: # nobody or npcs cannot loot
       if self.config.ITEM_SYSTEM_ENABLED:
         for item in list(self.inventory.items):

--- a/nmmo/entity/player.py
+++ b/nmmo/entity/player.py
@@ -1,8 +1,5 @@
-
-
 from nmmo.systems.skill import Skills
 from nmmo.systems.achievement import Diary
-from nmmo.systems import combat
 from nmmo.entity import entity
 
 # pylint: disable=no-member
@@ -48,7 +45,10 @@ class Player(entity.Entity):
 
   @property
   def level(self) -> int:
-    return combat.level(self.skills)
+    # a player's level is the max of all skills
+    # CHECK ME: the initial level is 1 because of Basic skills,
+    #   which are harvesting food/water and don't progress
+    return max(e.level.val for e in self.skills.skills)
 
   def apply_damage(self, dmg, style):
     super().apply_damage(dmg, style)

--- a/nmmo/entity/player.py
+++ b/nmmo/entity/player.py
@@ -59,32 +59,28 @@ class Player(entity.Entity):
     if self.immortal:
       return False
 
+    # super().receive_damage returns True if self is alive after taking dmg
     if super().receive_damage(source, dmg):
       return True
 
     if not self.config.ITEM_SYSTEM_ENABLED:
       return False
 
-    # if self is killed, source receive gold & inventory items
-    source.gold.increment(self.gold.val)
-    self.gold.update(0)
+    # starting from here, source receive gold & inventory items
+    if self.config.EXCHANGE_SYSTEM_ENABLED:
+      source.gold.increment(self.gold.val)
+      self.gold.update(0)
 
     # TODO(kywch): make source receive the highest-level items first
     #   because source cannot take it if the inventory is full
     #   Also, destroy the remaining items if the source cannot take those
     for item in list(self.inventory.items):
-      if not item.quantity.val:
-        item.datastore_record.delete()
-        continue
-
       self.inventory.remove(item)
+
+      # if source doesn't have space, inventory.receive() destroys the item
       source.inventory.receive(item)
 
-    if not super().receive_damage(source, dmg):
-      if source:
-        source.history.player_kills += 1
-      return False
-
+    # CHECK ME: this is an empty function. do we still need this?
     self.skills.receive_damage(dmg)
     return False
 

--- a/nmmo/io/action.py
+++ b/nmmo/io/action.py
@@ -218,12 +218,8 @@ class Attack(Node):
       if not config.COMBAT_FRIENDLY_FIRE and entity.is_player and entity.population_id.val == targ.population_id.val:
          return
 
-      #Check attack range
-      rng     = style.attackRange(config)
-      dif     = utils.linf(entity.pos, targ.pos)
-
-      #Can't attack same cell or out of range
-      if dif == 0 or dif > rng:
+      #Can't attack out of range
+      if utils.linf(entity.pos, targ.pos) > style.attackRange(config):
          return
 
       #Execute attack

--- a/nmmo/io/action.py
+++ b/nmmo/io/action.py
@@ -1,5 +1,7 @@
 # pylint: disable=all
 # TODO(kywch): If edits work, I will make it pass pylint
+#   also the env in call(env, entity, direction) functions below
+#   is actually realm. See realm.step() Should be changed.
 
 from ordered_set import OrderedSet
 import numpy as np
@@ -8,7 +10,7 @@ from enum import Enum, auto
 
 from nmmo.lib import utils
 from nmmo.lib.utils import staticproperty
-from nmmo.systems.item import Item
+from nmmo.systems.item import Item, Stack
 
 class NodeType(Enum):
    #Tree edges
@@ -97,9 +99,9 @@ class Action(Node):
       if config.COMBAT_SYSTEM_ENABLED:
           edges.append(Attack)
       if config.ITEM_SYSTEM_ENABLED:
-          edges += [Use]
+          edges += [Use, Give, Destroy]
       if config.EXCHANGE_SYSTEM_ENABLED:
-          edges += [Buy, Sell]
+          edges += [Buy, Sell, GiveGold]
       if config.COMMUNICATION_SYSTEM_ENABLED:
           edges.append(Comm)
       return edges
@@ -108,9 +110,11 @@ class Action(Node):
       raise NotImplementedError
 
 class Move(Node):
-   priority = 1
+   priority = 60
    nodeType = NodeType.SELECTION
    def call(env, entity, direction):
+      assert entity.alive, "Dead entity cannot act"
+
       r, c  = entity.pos
       ent_id = entity.ent_id
       entity.history.last_pos = (r, c)
@@ -164,7 +168,7 @@ class West(Node):
 
 
 class Attack(Node):
-   priority = 0
+   priority = 50
    nodeType = NodeType.SELECTION
    @staticproperty
    def n():
@@ -200,14 +204,16 @@ class Attack(Node):
       return abs(r - rCent) + abs(c - cCent)
 
    def call(env, entity, style, targ):
+      assert entity.alive, "Dead entity cannot act"
+      
       config = env.config
-
       if entity.is_player and not config.COMBAT_SYSTEM_ENABLED:
          return
 
       # Testing a spawn immunity against old agents to avoid spawn camping
       immunity = config.COMBAT_SPAWN_IMMUNITY
-      if entity.is_player and targ.is_player and entity.history.time_alive.val > immunity and targ.history.time_alive < immunity:
+      if entity.is_player and targ.is_player and \
+         targ.history.time_alive < immunity < entity.history.time_alive.val:
          return
 
       #Check if self targeted
@@ -255,6 +261,8 @@ class Target(Node):
       return config.PLAYER_N_OBS
 
    def deserialize(realm, entity, index):
+      # NOTE: index is the entity id
+      # CHECK ME: should index be renamed to ent_id?
       return realm.entity(index)
 
    def args(stim, entity, config):
@@ -304,6 +312,7 @@ class InventoryItem(Node):
         return stim.exchange.items()
 
     def deserialize(realm, entity, index):
+        # NOTE: index is from the inventory, NOT item id
         inventory = Item.Query.owned_by(realm.datastore, entity.id.val)
 
         if index >= inventory.shape[0]:
@@ -313,40 +322,135 @@ class InventoryItem(Node):
         return realm.items[item_id]
 
 class Use(Node):
-    priority = 3
+    priority = 10
 
     @staticproperty
     def edges():
         return [InventoryItem]
 
     def call(env, entity, item):
+        assert entity.alive, "Dead entity cannot act"
+        assert entity.is_player, "Npcs cannot use an item"
+        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+
+        if not env.config.ITEM_SYSTEM_ENABLED:
+           return
+
         if item not in entity.inventory:
+            return
+
+        # cannot use listed items or items that have higher level
+        if item.listed_price.val > 0 or item.level.val > item._level(entity):
             return
 
         return item.use(entity)
 
+class Destroy(Node):
+    priority = 40
+
+    @staticproperty
+    def edges():
+        return [InventoryItem]
+
+    def call(env, entity, item):
+        assert entity.alive, "Dead entity cannot act"
+        assert entity.is_player, "Npcs cannot destroy an item"
+        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+
+        if not env.config.ITEM_SYSTEM_ENABLED:
+           return
+
+        if item not in entity.inventory:
+            return
+
+        if item.equipped.val: # cannot destroy equipped item
+            return
+        
+        # inventory.remove() also unlists the item, if it has been listed
+        entity.inventory.remove(item)
+
+        return item.destroy()
+
 class Give(Node):
-    priority = 2
+    priority = 30
 
     @staticproperty
     def edges():
         return [InventoryItem, Target]
 
     def call(env, entity, item, target):
+        assert entity.alive, "Dead entity cannot act"
+        assert entity.is_player, "Npcs cannot give an item"
+        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+
+        config = env.config
+        if not config.ITEM_SYSTEM_ENABLED:
+           return
+
+        if not (target.is_player and target.alive):
+           return
+
         if item not in entity.inventory:
             return
 
-        if not target.is_player:
+        # cannot give the equipped or listed item
+        if item.equipped.val or item.listed_price.val:
+            return
+
+        if not (config.ITEM_GIVE_TO_FRIENDLY and
+                entity.population_id == target.population_id and        # the same team
+                entity.ent_id != target.ent_id and                      # but not self
+                utils.linf(entity.pos, target.pos) == 0):               # the same tile
             return
 
         if not target.inventory.space:
+            # receiver inventory is full - see if it has an ammo stack with the same sig
+            if isinstance(item, Stack):
+               if not target.inventory.has_stack(item.signature):
+                  # no ammo stack with the same signature, so cannot give
+                  return
+            else: # no space, and item is not ammo stack, so cannot give 
+               return
+
+        entity.inventory.remove(item)
+        return target.inventory.receive(item)
+
+
+class GiveGold(Node):
+    priority = 30
+
+    @staticproperty
+    def edges():
+        # CHECK ME: for now using Price to indicate the gold amount to give
+        return [Target, Price]
+
+    def call(env, entity, target, amount):
+        assert entity.alive, "Dead entity cannot act"
+        assert entity.is_player, "Npcs cannot give gold"
+
+        config = env.config
+        if not config.EXCHANGE_SYSTEM_ENABLED:
             return
 
-        entity.inventory.remove(item, quantity=1)
-        item = type(item)(env, item.level.val)
-        target.inventory.receive(item)
+        if not (target.is_player and target.alive):
+           return
 
-        return True
+        if not (config.ITEM_GIVE_TO_FRIENDLY and
+                entity.population_id == target.population_id and        # the same team
+                entity.ent_id != target.ent_id and                      # but not self
+                utils.linf(entity.pos, target.pos) == 0):               # the same tile
+            return
+
+        if type(amount) != int:
+            amount = amount.val
+
+        if not (amount > 0 and entity.gold.val > 0): # no gold to give
+           return
+
+        amount = min(amount, entity.gold.val)
+
+        entity.gold.decrement(amount)
+        return target.gold.increment(amount)
 
 
 class MarketItem(Node):
@@ -361,6 +465,7 @@ class MarketItem(Node):
         return stim.exchange.items()
 
     def deserialize(realm, entity, index):
+        # NOTE: index is from the market, NOT item id
         market = Item.Query.for_sale(realm.datastore)
 
         if index >= market.shape[0]:
@@ -370,7 +475,7 @@ class MarketItem(Node):
         return realm.items[item_id]
 
 class Buy(Node):
-    priority = 4
+    priority = 20
     argType  = Fixed
 
     @staticproperty
@@ -378,17 +483,34 @@ class Buy(Node):
         return [MarketItem]
 
     def call(env, entity, item):
-        #Do not process exchange actions on death tick
-        if not entity.alive:
+        assert entity.alive, "Dead entity cannot act"
+        assert entity.is_player, "Npcs cannot buy an item"
+        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+        assert item.equipped.val == 0, 'Listed item must not be equipped'
+
+        if not env.config.EXCHANGE_SYSTEM_ENABLED:
+            return
+
+        if entity.gold.val < item.listed_price.val: # not enough money
+            return
+        
+        if entity.ent_id == item.owner_id.val: # cannot buy own item
             return
 
         if not entity.inventory.space:
-            return
+            # buyer inventory is full - see if it has an ammo stack with the same sig
+            if isinstance(item, Stack):
+               if not entity.inventory.has_stack(item.signature):
+                  # no ammo stack with the same signature, so cannot give
+                  return
+            else: # no space, and item is not ammo stack, so cannot give 
+               return
 
+        # one can try to buy, but the listing might have gone (perhaps bought by other)
         return env.exchange.buy(entity, item)
 
 class Sell(Node):
-    priority = 4
+    priority = 70
     argType  = Fixed
 
     @staticproperty
@@ -396,18 +518,29 @@ class Sell(Node):
         return [InventoryItem, Price]
 
     def call(env, entity, item, price):
-        #Do not process exchange actions on death tick
-        if not entity.alive:
+        assert entity.alive, "Dead entity cannot act"
+        assert entity.is_player, "Npcs cannot sell an item"
+        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+
+        if not env.config.EXCHANGE_SYSTEM_ENABLED:
             return
 
         # TODO: Find a better way to check this
         # Should only occur when item is used on same tick
         # Otherwise should not be possible
+        #   >> This should involve env._validate_actions, and perhaps action priotities
         if item not in entity.inventory:
+            return
+
+        # cannot sell the equipped or listed item
+        if item.equipped.val or item.listed_price.val:
             return
 
         if type(price) != int:
             price = price.val
+
+        if not (price > 0):
+           return
 
         return env.exchange.sell(entity, item, price, env.tick)
 
@@ -424,7 +557,7 @@ class Price(Node):
 
     @classmethod
     def init(cls, config):
-        Price.classes = init_discrete(list(range(100)))
+        Price.classes = init_discrete(range(1, 101)) # gold should be > 0 
 
     @staticproperty
     def edges():
@@ -449,7 +582,7 @@ class Token(Node):
 
 class Comm(Node):
     argType  = Fixed
-    priority = 0
+    priority = 99
 
     @staticproperty
     def edges():

--- a/nmmo/io/action.py
+++ b/nmmo/io/action.py
@@ -1,596 +1,592 @@
-# pylint: disable=all
-# TODO(kywch): If edits work, I will make it pass pylint
-#   also the env in call(env, entity, direction) functions below
-#   is actually realm. See realm.step() Should be changed.
-
-from ordered_set import OrderedSet
-import numpy as np
+# CHECK ME: Should these be fixed as well?
+# pylint: disable=no-method-argument,unused-argument,no-self-argument,no-member
 
 from enum import Enum, auto
+from ordered_set import OrderedSet
 
 from nmmo.lib import utils
 from nmmo.lib.utils import staticproperty
 from nmmo.systems.item import Item, Stack
 
 class NodeType(Enum):
-   #Tree edges
-   STATIC = auto()    #Traverses all edges without decisions
-   SELECTION = auto() #Picks an edge to follow
+  #Tree edges
+  STATIC = auto()    #Traverses all edges without decisions
+  SELECTION = auto() #Picks an edge to follow
 
-   #Executable actions
-   ACTION    = auto() #No arguments
-   CONSTANT  = auto() #Constant argument
-   VARIABLE  = auto() #Variable argument
+  #Executable actions
+  ACTION    = auto() #No arguments
+  CONSTANT  = auto() #Constant argument
+  VARIABLE  = auto() #Variable argument
 
 class Node(metaclass=utils.IterableNameComparable):
-   @classmethod
-   def init(cls, config):
-       pass
+  @classmethod
+  def init(cls, config):
+    pass
 
-   @staticproperty
-   def edges():
-      return []
+  @staticproperty
+  def edges():
+    return []
 
-   #Fill these in
-   @staticproperty
-   def priority():
-      return None
+  #Fill these in
+  @staticproperty
+  def priority():
+    return None
 
-   @staticproperty
-   def type():
-      return None
+  @staticproperty
+  def type():
+    return None
 
-   @staticproperty
-   def leaf():
-      return False
+  @staticproperty
+  def leaf():
+    return False
 
-   @classmethod
-   def N(cls, config):
-      return len(cls.edges)
+  @classmethod
+  def N(cls, config):
+    return len(cls.edges)
 
-   def deserialize(realm, entity, index):
-      return index
+  def deserialize(realm, entity, index):
+    return index
 
-   def args(stim, entity, config):
-      return []
+  def args(stim, entity, config):
+    return []
 
 class Fixed:
-   pass
+  pass
 
 #ActionRoot
 class Action(Node):
-   nodeType = NodeType.SELECTION
-   hooked   = False
+  nodeType = NodeType.SELECTION
+  hooked   = False
 
-   @classmethod
-   def init(cls, config):
-      # Sets up serialization domain
-      if Action.hooked:
-          return
+  @classmethod
+  def init(cls, config):
+    # Sets up serialization domain
+    if Action.hooked:
+      return
 
-      Action.hooked = True
+    Action.hooked = True
 
-   #Called upon module import (see bottom of file)
-   #Sets up serialization domain
-   def hook(config):
-      idx = 0
-      arguments = []
-      for action in Action.edges(config):
-         action.init(config)
-         for args in action.edges:
-            args.init(config)
-            if not 'edges' in args.__dict__:
-               continue
-            for arg in args.edges:
-               arguments.append(arg)
-               arg.serial = tuple([idx])
-               arg.idx = idx
-               idx += 1
-      Action.arguments = arguments
+  #Called upon module import (see bottom of file)
+  #Sets up serialization domain
+  def hook(config):
+    idx = 0
+    arguments = []
+    for action in Action.edges(config):
+      action.init(config)
+      for args in action.edges:
+        args.init(config)
+        if not 'edges' in args.__dict__:
+          continue
+        for arg in args.edges:
+          arguments.append(arg)
+          arg.serial = tuple([idx])
+          arg.idx = idx
+          idx += 1
+    Action.arguments = arguments
 
-   @staticproperty
-   def n():
-      return len(Action.arguments)
+  @staticproperty
+  def n():
+    return len(Action.arguments)
 
-   @classmethod
-   def edges(cls, config):
-      '''List of valid actions'''
-      edges = [Move]
-      if config.COMBAT_SYSTEM_ENABLED:
-          edges.append(Attack)
-      if config.ITEM_SYSTEM_ENABLED:
-          edges += [Use, Give, Destroy]
-      if config.EXCHANGE_SYSTEM_ENABLED:
-          edges += [Buy, Sell, GiveGold]
-      if config.COMMUNICATION_SYSTEM_ENABLED:
-          edges.append(Comm)
-      return edges
+  # pylint: disable=invalid-overridden-method
+  @classmethod
+  def edges(cls, config):
+    '''List of valid actions'''
+    edges = [Move]
+    if config.COMBAT_SYSTEM_ENABLED:
+      edges.append(Attack)
+    if config.ITEM_SYSTEM_ENABLED:
+      edges += [Use, Give, Destroy]
+    if config.EXCHANGE_SYSTEM_ENABLED:
+      edges += [Buy, Sell, GiveGold]
+    if config.COMMUNICATION_SYSTEM_ENABLED:
+      edges.append(Comm)
+    return edges
 
-   def args(stim, entity, config):
-      raise NotImplementedError
+  def args(stim, entity, config):
+    raise NotImplementedError
 
 class Move(Node):
-   priority = 60
-   nodeType = NodeType.SELECTION
-   def call(env, entity, direction):
-      assert entity.alive, "Dead entity cannot act"
+  priority = 60
+  nodeType = NodeType.SELECTION
+  def call(realm, entity, direction):
+    assert entity.alive, "Dead entity cannot act"
 
-      r, c  = entity.pos
-      ent_id = entity.ent_id
-      entity.history.last_pos = (r, c)
-      r_delta, c_delta = direction.delta
-      rNew, cNew = r+r_delta, c+c_delta
+    r, c  = entity.pos
+    ent_id = entity.ent_id
+    entity.history.last_pos = (r, c)
+    r_delta, c_delta = direction.delta
+    r_new, c_new = r+r_delta, c+c_delta
 
-      # One agent per cell
-      tile = env.map.tiles[rNew, cNew]
+    if entity.status.freeze > 0:
+      return
 
-      if entity.status.freeze > 0:
-         return
+    entity.row.update(r_new)
+    entity.col.update(c_new)
 
-      entity.row.update(rNew)
-      entity.col.update(cNew)
+    realm.map.tiles[r, c].remove_entity(ent_id)
+    realm.map.tiles[r_new, c_new].add_entity(entity)
 
-      env.map.tiles[r, c].remove_entity(ent_id)
-      env.map.tiles[rNew, cNew].add_entity(entity)
+    if realm.map.tiles[r_new, c_new].lava:
+      entity.receive_damage(None, entity.resources.health.val)
 
-      if env.map.tiles[rNew, cNew].lava:
-         entity.receive_damage(None, entity.resources.health.val)
+  @staticproperty
+  def edges():
+    return [Direction]
 
-   @staticproperty
-   def edges():
-      return [Direction]
-
-   @staticproperty
-   def leaf():
-      return True
+  @staticproperty
+  def leaf():
+    return True
 
 class Direction(Node):
-   argType = Fixed
+  argType = Fixed
 
-   @staticproperty
-   def edges():
-      return [North, South, East, West]
+  @staticproperty
+  def edges():
+    return [North, South, East, West]
 
-   def args(stim, entity, config):
-      return Direction.edges
+  def args(stim, entity, config):
+    return Direction.edges
 
 class North(Node):
-   delta = (-1, 0)
+  delta = (-1, 0)
 
 class South(Node):
-   delta = (1, 0)
+  delta = (1, 0)
 
 class East(Node):
-   delta = (0, 1)
+  delta = (0, 1)
 
 class West(Node):
-   delta = (0, -1)
+  delta = (0, -1)
 
 
 class Attack(Node):
-   priority = 50
-   nodeType = NodeType.SELECTION
-   @staticproperty
-   def n():
-      return 3
+  priority = 50
+  nodeType = NodeType.SELECTION
+  @staticproperty
+  def n():
+    return 3
 
-   @staticproperty
-   def edges():
-      return [Style, Target]
+  @staticproperty
+  def edges():
+    return [Style, Target]
 
-   @staticproperty
-   def leaf():
-      return True
+  @staticproperty
+  def leaf():
+    return True
 
-   def inRange(entity, stim, config, N):
-      R, C = stim.shape
-      R, C = R//2, C//2
 
-      rets = OrderedSet([entity])
-      for r in range(R-N, R+N+1):
-         for c in range(C-N, C+N+1):
-            for e in stim[r, c].entities.values():
-               rets.add(e)
+  def in_range(entity, stim, config, N):
+    R, C = stim.shape
+    R, C = R//2, C//2
 
-      rets = list(rets)
-      return rets
+    rets = OrderedSet([entity])
+    for r in range(R-N, R+N+1):
+      for c in range(C-N, C+N+1):
+        for e in stim[r, c].entities.values():
+          rets.add(e)
 
-   # CHECK ME: do we need l1 distance function?
-   #   systems/ai/utils.py also has various distance functions
-   #   which we may want to clean up
-   def l1(pos, cent):
-      r, c = pos
-      rCent, cCent = cent
-      return abs(r - rCent) + abs(c - cCent)
+    rets = list(rets)
+    return rets
 
-   def call(env, entity, style, targ):
-      assert entity.alive, "Dead entity cannot act"
-      
-      config = env.config
-      if entity.is_player and not config.COMBAT_SYSTEM_ENABLED:
-         return
+  # CHECK ME: do we need l1 distance function?
+  #   systems/ai/utils.py also has various distance functions
+  #   which we may want to clean up
+  # def l1(pos, cent):
+  #   r, c = pos
+  #   r_cent, c_cent = cent
+  #   return abs(r - r_cent) + abs(c - c_cent)
 
-      # Testing a spawn immunity against old agents to avoid spawn camping
-      immunity = config.COMBAT_SPAWN_IMMUNITY
-      if entity.is_player and targ.is_player and \
-         targ.history.time_alive < immunity < entity.history.time_alive.val:
-         return
+  def call(realm, entity, style, targ):
+    assert entity.alive, "Dead entity cannot act"
 
-      #Check if self targeted
-      if entity.ent_id == targ.ent_id:
-         return
+    config = realm.config
+    if entity.is_player and not config.COMBAT_SYSTEM_ENABLED:
+      return None
 
-      #ADDED: POPULATION IMMUNITY
-      if not config.COMBAT_FRIENDLY_FIRE and entity.is_player and entity.population_id.val == targ.population_id.val:
-         return
+    # Testing a spawn immunity against old agents to avoid spawn camping
+    immunity = config.COMBAT_SPAWN_IMMUNITY
+    if entity.is_player and targ.is_player and \
+      targ.history.time_alive < immunity < entity.history.time_alive.val:
+      return None
 
-      #Can't attack out of range
-      if utils.linf(entity.pos, targ.pos) > style.attackRange(config):
-         return
+    #Check if self targeted
+    if entity.ent_id == targ.ent_id:
+      return None
 
-      #Execute attack
-      entity.history.attack = {}
-      entity.history.attack['target'] = targ.ent_id
-      entity.history.attack['style'] = style.__name__
-      targ.attacker = entity
-      targ.attacker_id.update(entity.ent_id)
+    #ADDED: POPULATION IMMUNITY
+    if not config.COMBAT_FRIENDLY_FIRE and entity.is_player \
+       and entity.population_id.val == targ.population_id.val:
+      return None
 
-      from nmmo.systems import combat
-      dmg = combat.attack(env, entity, targ, style.skill)
+    #Can't attack out of range
+    if utils.linf(entity.pos, targ.pos) > style.attack_range(config):
+      return None
 
-      if style.freeze and dmg > 0:
-         targ.status.freeze.update(config.COMBAT_FREEZE_TIME)
+    #Execute attack
+    entity.history.attack = {}
+    entity.history.attack['target'] = targ.ent_id
+    entity.history.attack['style'] = style.__name__
+    targ.attacker = entity
+    targ.attacker_id.update(entity.ent_id)
 
-      return dmg
+    from nmmo.systems import combat
+    dmg = combat.attack(realm, entity, targ, style.skill)
+
+    if style.freeze and dmg > 0:
+      targ.status.freeze.update(config.COMBAT_FREEZE_TIME)
+
+    return dmg
 
 class Style(Node):
-   argType = Fixed
-   @staticproperty
-   def edges():
-      return [Melee, Range, Mage]
+  argType = Fixed
+  @staticproperty
+  def edges():
+    return [Melee, Range, Mage]
 
-   def args(stim, entity, config):
-      return Style.edges
+  def args(stim, entity, config):
+    return Style.edges
 
 
 class Target(Node):
-   argType = None
+  argType = None
 
-   @classmethod
-   def N(cls, config):
-      return config.PLAYER_N_OBS
+  @classmethod
+  def N(cls, config):
+    return config.PLAYER_N_OBS
 
-   def deserialize(realm, entity, index):
-      # NOTE: index is the entity id
-      # CHECK ME: should index be renamed to ent_id?
-      return realm.entity(index)
+  def deserialize(realm, entity, index):
+    # NOTE: index is the entity id
+    # CHECK ME: should index be renamed to ent_id?
+    return realm.entity(index)
 
-   def args(stim, entity, config):
-      #Should pass max range?
-      return Attack.inRange(entity, stim, config, None)
+  def args(stim, entity, config):
+    #Should pass max range?
+    return Attack.in_range(entity, stim, config, None)
 
 class Melee(Node):
-   nodeType = NodeType.ACTION
-   freeze=False
+  nodeType = NodeType.ACTION
+  freeze=False
 
-   def attackRange(config):
-      return config.COMBAT_MELEE_REACH
+  def attack_range(config):
+    return config.COMBAT_MELEE_REACH
 
-   def skill(entity):
-      return entity.skills.melee
+  def skill(entity):
+    return entity.skills.melee
 
 class Range(Node):
-   nodeType = NodeType.ACTION
-   freeze=False
+  nodeType = NodeType.ACTION
+  freeze=False
 
-   def attackRange(config):
-      return config.COMBAT_RANGE_REACH
+  def attack_range(config):
+    return config.COMBAT_RANGE_REACH
 
-   def skill(entity):
-      return entity.skills.range
+  def skill(entity):
+    return entity.skills.range
 
 class Mage(Node):
-   nodeType = NodeType.ACTION
-   freeze=False
+  nodeType = NodeType.ACTION
+  freeze=False
 
-   def attackRange(config):
-      return config.COMBAT_MAGE_REACH
+  def attack_range(config):
+    return config.COMBAT_MAGE_REACH
 
-   def skill(entity):
-      return entity.skills.mage
+  def skill(entity):
+    return entity.skills.mage
 
 
 class InventoryItem(Node):
-    argType  = None
+  argType  = None
 
-    @classmethod
-    def N(cls, config):
-        return config.INVENTORY_N_OBS
+  @classmethod
+  def N(cls, config):
+    return config.INVENTORY_N_OBS
 
-    # TODO(kywch): What does args do?
-    def args(stim, entity, config):
-        return stim.exchange.items()
+  # TODO(kywch): What does args do?
+  def args(stim, entity, config):
+    return stim.exchange.items()
 
-    def deserialize(realm, entity, index):
-        # NOTE: index is from the inventory, NOT item id
-        inventory = Item.Query.owned_by(realm.datastore, entity.id.val)
+  def deserialize(realm, entity, index):
+    # NOTE: index is from the inventory, NOT item id
+    inventory = Item.Query.owned_by(realm.datastore, entity.id.val)
 
-        if index >= inventory.shape[0]:
-            return None
+    if index >= inventory.shape[0]:
+      return None
 
-        item_id = inventory[index, Item.State.attr_name_to_col["id"]]
-        return realm.items[item_id]
+    item_id = inventory[index, Item.State.attr_name_to_col["id"]]
+    return realm.items[item_id]
 
 class Use(Node):
-    priority = 10
+  priority = 10
 
-    @staticproperty
-    def edges():
-        return [InventoryItem]
+  @staticproperty
+  def edges():
+    return [InventoryItem]
 
-    def call(env, entity, item):
-        assert entity.alive, "Dead entity cannot act"
-        assert entity.is_player, "Npcs cannot use an item"
-        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+  def call(realm, entity, item):
+    assert entity.alive, "Dead entity cannot act"
+    assert entity.is_player, "Npcs cannot use an item"
+    assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
 
-        if not env.config.ITEM_SYSTEM_ENABLED:
-           return
+    if not realm.config.ITEM_SYSTEM_ENABLED:
+      return
 
-        if item not in entity.inventory:
-            return
+    if item not in entity.inventory:
+      return
 
-        # cannot use listed items or items that have higher level
-        if item.listed_price.val > 0 or item.level.val > item._level(entity):
-            return
+    # cannot use listed items or items that have higher level
+    if item.listed_price.val > 0 or item.level_gt(entity):
+      return
 
-        return item.use(entity)
+    item.use(entity)
 
 class Destroy(Node):
-    priority = 40
+  priority = 40
 
-    @staticproperty
-    def edges():
-        return [InventoryItem]
+  @staticproperty
+  def edges():
+    return [InventoryItem]
 
-    def call(env, entity, item):
-        assert entity.alive, "Dead entity cannot act"
-        assert entity.is_player, "Npcs cannot destroy an item"
-        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+  def call(realm, entity, item):
+    assert entity.alive, "Dead entity cannot act"
+    assert entity.is_player, "Npcs cannot destroy an item"
+    assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
 
-        if not env.config.ITEM_SYSTEM_ENABLED:
-           return
+    if not realm.config.ITEM_SYSTEM_ENABLED:
+      return
 
-        if item not in entity.inventory:
-            return
+    if item not in entity.inventory:
+      return
 
-        if item.equipped.val: # cannot destroy equipped item
-            return
-        
-        # inventory.remove() also unlists the item, if it has been listed
-        entity.inventory.remove(item)
+    if item.equipped.val: # cannot destroy equipped item
+      return
 
-        return item.destroy()
+    # inventory.remove() also unlists the item, if it has been listed
+    entity.inventory.remove(item)
+    item.destroy()
 
 class Give(Node):
-    priority = 30
+  priority = 30
 
-    @staticproperty
-    def edges():
-        return [InventoryItem, Target]
+  @staticproperty
+  def edges():
+    return [InventoryItem, Target]
 
-    def call(env, entity, item, target):
-        assert entity.alive, "Dead entity cannot act"
-        assert entity.is_player, "Npcs cannot give an item"
-        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+  def call(realm, entity, item, target):
+    assert entity.alive, "Dead entity cannot act"
+    assert entity.is_player, "Npcs cannot give an item"
+    assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
 
-        config = env.config
-        if not config.ITEM_SYSTEM_ENABLED:
-           return
+    config = realm.config
+    if not config.ITEM_SYSTEM_ENABLED:
+      return
 
-        if not (target.is_player and target.alive):
-           return
+    if not (target.is_player and target.alive):
+      return
 
-        if item not in entity.inventory:
-            return
+    if item not in entity.inventory:
+      return
 
-        # cannot give the equipped or listed item
-        if item.equipped.val or item.listed_price.val:
-            return
+    # cannot give the equipped or listed item
+    if item.equipped.val or item.listed_price.val:
+      return
 
-        if not (config.ITEM_GIVE_TO_FRIENDLY and
-                entity.population_id == target.population_id and        # the same team
-                entity.ent_id != target.ent_id and                      # but not self
-                utils.linf(entity.pos, target.pos) == 0):               # the same tile
-            return
+    if not (config.ITEM_GIVE_TO_FRIENDLY and
+            entity.population_id == target.population_id and        # the same team
+            entity.ent_id != target.ent_id and                      # but not self
+            utils.linf(entity.pos, target.pos) == 0):               # the same tile
+      return
 
-        if not target.inventory.space:
-            # receiver inventory is full - see if it has an ammo stack with the same sig
-            if isinstance(item, Stack):
-               if not target.inventory.has_stack(item.signature):
-                  # no ammo stack with the same signature, so cannot give
-                  return
-            else: # no space, and item is not ammo stack, so cannot give 
-               return
+    if not target.inventory.space:
+      # receiver inventory is full - see if it has an ammo stack with the same sig
+      if isinstance(item, Stack):
+        if not target.inventory.has_stack(item.signature):
+          # no ammo stack with the same signature, so cannot give
+          return
+      else: # no space, and item is not ammo stack, so cannot give
+        return
 
-        entity.inventory.remove(item)
-        return target.inventory.receive(item)
+    entity.inventory.remove(item)
+    target.inventory.receive(item)
 
 
 class GiveGold(Node):
-    priority = 30
+  priority = 30
 
-    @staticproperty
-    def edges():
-        # CHECK ME: for now using Price to indicate the gold amount to give
-        return [Target, Price]
+  @staticproperty
+  def edges():
+    # CHECK ME: for now using Price to indicate the gold amount to give
+    return [Target, Price]
 
-    def call(env, entity, target, amount):
-        assert entity.alive, "Dead entity cannot act"
-        assert entity.is_player, "Npcs cannot give gold"
+  def call(realm, entity, target, amount):
+    assert entity.alive, "Dead entity cannot act"
+    assert entity.is_player, "Npcs cannot give gold"
 
-        config = env.config
-        if not config.EXCHANGE_SYSTEM_ENABLED:
-            return
+    config = realm.config
+    if not config.EXCHANGE_SYSTEM_ENABLED:
+      return
 
-        if not (target.is_player and target.alive):
-           return
+    if not (target.is_player and target.alive):
+      return
 
-        if not (config.ITEM_GIVE_TO_FRIENDLY and
-                entity.population_id == target.population_id and        # the same team
-                entity.ent_id != target.ent_id and                      # but not self
-                utils.linf(entity.pos, target.pos) == 0):               # the same tile
-            return
+    if not (config.ITEM_GIVE_TO_FRIENDLY and
+            entity.population_id == target.population_id and        # the same team
+            entity.ent_id != target.ent_id and                      # but not self
+            utils.linf(entity.pos, target.pos) == 0):               # the same tile
+      return
 
-        if type(amount) != int:
-            amount = amount.val
+    if not isinstance(amount, int):
+      amount = amount.val
 
-        if not (amount > 0 and entity.gold.val > 0): # no gold to give
-           return
+    if not (amount > 0 and entity.gold.val > 0): # no gold to give
+      return
 
-        amount = min(amount, entity.gold.val)
+    amount = min(amount, entity.gold.val)
 
-        entity.gold.decrement(amount)
-        return target.gold.increment(amount)
+    entity.gold.decrement(amount)
+    target.gold.increment(amount)
 
 
 class MarketItem(Node):
-    argType  = None
+  argType  = None
 
-    @classmethod
-    def N(cls, config):
-        return config.MARKET_N_OBS
+  @classmethod
+  def N(cls, config):
+    return config.MARKET_N_OBS
 
-    # TODO(kywch): What does args do?
-    def args(stim, entity, config):
-        return stim.exchange.items()
+  # TODO(kywch): What does args do?
+  def args(stim, entity, config):
+    return stim.exchange.items()
 
-    def deserialize(realm, entity, index):
-        # NOTE: index is from the market, NOT item id
-        market = Item.Query.for_sale(realm.datastore)
+  def deserialize(realm, entity, index):
+    # NOTE: index is from the market, NOT item id
+    market = Item.Query.for_sale(realm.datastore)
 
-        if index >= market.shape[0]:
-            return None
-        
-        item_id = market[index, Item.State.attr_name_to_col["id"]]
-        return realm.items[item_id]
+    if index >= market.shape[0]:
+      return None
+
+    item_id = market[index, Item.State.attr_name_to_col["id"]]
+    return realm.items[item_id]
 
 class Buy(Node):
-    priority = 20
-    argType  = Fixed
+  priority = 20
+  argType  = Fixed
 
-    @staticproperty
-    def edges():
-        return [MarketItem]
+  @staticproperty
+  def edges():
+    return [MarketItem]
 
-    def call(env, entity, item):
-        assert entity.alive, "Dead entity cannot act"
-        assert entity.is_player, "Npcs cannot buy an item"
-        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
-        assert item.equipped.val == 0, 'Listed item must not be equipped'
+  def call(realm, entity, item):
+    assert entity.alive, "Dead entity cannot act"
+    assert entity.is_player, "Npcs cannot buy an item"
+    assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+    assert item.equipped.val == 0, 'Listed item must not be equipped'
 
-        if not env.config.EXCHANGE_SYSTEM_ENABLED:
-            return
+    if not realm.config.EXCHANGE_SYSTEM_ENABLED:
+      return
 
-        if entity.gold.val < item.listed_price.val: # not enough money
-            return
-        
-        if entity.ent_id == item.owner_id.val: # cannot buy own item
-            return
+    if entity.gold.val < item.listed_price.val: # not enough money
+      return
 
-        if not entity.inventory.space:
-            # buyer inventory is full - see if it has an ammo stack with the same sig
-            if isinstance(item, Stack):
-               if not entity.inventory.has_stack(item.signature):
-                  # no ammo stack with the same signature, so cannot give
-                  return
-            else: # no space, and item is not ammo stack, so cannot give 
-               return
+    if entity.ent_id == item.owner_id.val: # cannot buy own item
+      return
 
-        # one can try to buy, but the listing might have gone (perhaps bought by other)
-        return env.exchange.buy(entity, item)
+    if not entity.inventory.space:
+      # buyer inventory is full - see if it has an ammo stack with the same sig
+      if isinstance(item, Stack):
+        if not entity.inventory.has_stack(item.signature):
+          # no ammo stack with the same signature, so cannot give
+          return
+      else: # no space, and item is not ammo stack, so cannot give
+        return
+
+    # one can try to buy, but the listing might have gone (perhaps bought by other)
+    realm.exchange.buy(entity, item)
 
 class Sell(Node):
-    priority = 70
-    argType  = Fixed
+  priority = 70
+  argType  = Fixed
 
-    @staticproperty
-    def edges():
-        return [InventoryItem, Price]
+  @staticproperty
+  def edges():
+    return [InventoryItem, Price]
 
-    def call(env, entity, item, price):
-        assert entity.alive, "Dead entity cannot act"
-        assert entity.is_player, "Npcs cannot sell an item"
-        assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
+  def call(realm, entity, item, price):
+    assert entity.alive, "Dead entity cannot act"
+    assert entity.is_player, "Npcs cannot sell an item"
+    assert item.quantity.val > 0, "Item quantity cannot be 0" # indicates item leak
 
-        if not env.config.EXCHANGE_SYSTEM_ENABLED:
-            return
+    if not realm.config.EXCHANGE_SYSTEM_ENABLED:
+      return
 
-        # TODO: Find a better way to check this
-        # Should only occur when item is used on same tick
-        # Otherwise should not be possible
-        #   >> This should involve env._validate_actions, and perhaps action priotities
-        if item not in entity.inventory:
-            return
+    # TODO(kywch): Find a better way to check this
+    # Should only occur when item is used on same tick
+    # Otherwise should not be possible
+    #   >> Actions on the same item should be checked at env._validate_actions
+    if item not in entity.inventory:
+      return
 
-        # cannot sell the equipped or listed item
-        if item.equipped.val or item.listed_price.val:
-            return
+    # cannot sell the equipped or listed item
+    if item.equipped.val or item.listed_price.val:
+      return
 
-        if type(price) != int:
-            price = price.val
+    if not isinstance(price, int):
+      price = price.val
 
-        if not (price > 0):
-           return
+    if not price > 0:
+      return
 
-        return env.exchange.sell(entity, item, price, env.tick)
+    realm.exchange.sell(entity, item, price, realm.tick)
 
 def init_discrete(values):
-    classes = []
-    for i in values:
-        name = f'Discrete_{i}'
-        cls  = type(name, (object,), {'val': i})
-        classes.append(cls)
-    return classes
+  classes = []
+  for i in values:
+    name = f'Discrete_{i}'
+    cls  = type(name, (object,), {'val': i})
+    classes.append(cls)
+
+  return classes
 
 class Price(Node):
-    argType  = Fixed
+  argType  = Fixed
 
-    @classmethod
-    def init(cls, config):
-        Price.classes = init_discrete(range(1, 101)) # gold should be > 0 
+  @classmethod
+  def init(cls, config):
+    Price.classes = init_discrete(range(1, 101)) # gold should be > 0
 
-    @staticproperty
-    def edges():
-        return Price.classes
+  @staticproperty
+  def edges():
+    return Price.classes
 
-    def args(stim, entity, config):
-        return Price.edges
+  def args(stim, entity, config):
+    return Price.edges
 
 class Token(Node):
-    argType  = Fixed
+  argType  = Fixed
 
-    @classmethod
-    def init(cls, config):
-        Comm.classes = init_discrete(range(config.COMMUNICATION_NUM_TOKENS))
+  @classmethod
+  def init(cls, config):
+    Comm.classes = init_discrete(range(config.COMMUNICATION_NUM_TOKENS))
 
-    @staticproperty
-    def edges():
-        return Comm.classes
+  @staticproperty
+  def edges():
+    return Comm.classes
 
-    def args(stim, entity, config):
-        return Comm.edges
+  def args(stim, entity, config):
+    return Comm.edges
 
 class Comm(Node):
-    argType  = Fixed
-    priority = 99
+  argType  = Fixed
+  priority = 99
 
-    @staticproperty
-    def edges():
-        return [Token]
+  @staticproperty
+  def edges():
+    return [Token]
 
-    def call(env, entity, token):
-        entity.message.update(token.val)
+  def call(realm, entity, token):
+    entity.message.update(token.val)
 
 #TODO: Solve AGI
 class BecomeSkynet:
-   pass
+  pass

--- a/nmmo/io/action.py
+++ b/nmmo/io/action.py
@@ -191,6 +191,9 @@ class Attack(Node):
       rets = list(rets)
       return rets
 
+   # CHECK ME: do we need l1 distance function?
+   #   systems/ai/utils.py also has various distance functions
+   #   which we may want to clean up
    def l1(pos, cent):
       r, c = pos
       rCent, cCent = cent
@@ -217,9 +220,7 @@ class Attack(Node):
 
       #Check attack range
       rng     = style.attackRange(config)
-      start   = np.array(entity.pos)
-      end     = np.array(targ.pos)
-      dif     = np.max(np.abs(start - end))
+      dif     = utils.linf(entity.pos, targ.pos)
 
       #Can't attack same cell or out of range
       if dif == 0 or dif > rng:

--- a/nmmo/lib/utils.py
+++ b/nmmo/lib/utils.py
@@ -74,9 +74,9 @@ def seed():
   return int(np.random.randint(0, 2**32))
 
 def linf(pos1, pos2):
-  r1, c1 = pos1
-  r2, c2 = pos2
-  return max(abs(r1 - r2), abs(c1 - c2))
+  # pos could be a single (r,c) or a vector of (r,c)s
+  diff = np.abs(np.array(pos1) - np.array(pos2))
+  return np.max(diff, axis=len(diff.shape)-1)  
 
 #Bounds checker
 def in_bounds(r, c, shape, border=0):

--- a/nmmo/systems/ai/behavior.py
+++ b/nmmo/systems/ai/behavior.py
@@ -64,7 +64,7 @@ def hunt(realm, actions, entity):
 
 def attack(realm, actions, entity):
    distance = utils.lInfty(entity.pos, entity.target.pos)
-   if distance > entity.skills.style.attackRange(realm.config):
+   if distance > entity.skills.style.attack_range(realm.config):
       return
 
    actions[nmmo.action.Attack] = {

--- a/nmmo/systems/ai/utils.py
+++ b/nmmo/systems/ai/utils.py
@@ -51,7 +51,8 @@ def closestTarget(ent, tiles, rng=1):
             if e is not ent and validTarget(ent, e, rng): return e
 
 def distance(ent, targ):
-   return l1(ent.pos, targ.pos)
+   # used in scripted/behavior.py, attack() to determine attack range
+   return lInfty(ent.pos, targ.pos)
 
 def lInf(ent, targ):
    sr, sc = ent.pos

--- a/nmmo/systems/combat.py
+++ b/nmmo/systems/combat.py
@@ -29,12 +29,6 @@ def attack(realm, player, target, skillFn):
     skill_type   = type(skill)
     skill_name   = skill_type.__name__
 
-    # Ammunition usage
-    if config.EQUIPMENT_SYSTEM_ENABLED:
-        ammunition = player.equipment.ammunition.item
-        if ammunition is not None:
-            ammunition.fire(player)
-
     # Per-style offense/defense
     level_damage = 0
     if skill_type == Skill.Melee:
@@ -80,6 +74,16 @@ def attack(realm, player, target, skillFn):
     if config.EQUIPMENT_SYSTEM_ENABLED:
         equipment_offense = player.equipment.total(offense_fn)
         equipment_defense = target.equipment.total(defense_fn)
+
+        # for debug
+        equipment_level_offense = player.equipment.total(lambda e: e.level)
+        equipment_level_defense = target.equipment.total(lambda e: e.level)
+
+        # after tallying ammo damage, consume ammo (i.e., fire)
+        ammunition = player.equipment.ammunition.item
+        if ammunition is not None:
+            ammunition.fire(player)
+
     else:
         equipment_offense = 0
         equipment_defense = 0
@@ -94,8 +98,8 @@ def attack(realm, player, target, skillFn):
     if player.is_player:
         realm.log_milestone(f'Damage_{skill_name}', damage,
                             f'COMBAT: Inflicted {damage} {skill_name} damage ' +
-                            f'(lvl {player.equipment.total(lambda e: e.level)} vs ' +
-                            f'lvl {target.equipment.total(lambda e: e.level)})',
+                            f'(attack equip lvl {equipment_level_offense} vs ' +
+                            f'defense equip lvl {equipment_level_defense})',
                             tags={"player_id": player.ent_id})
 
     player.apply_damage(damage, skill.__class__.__name__.lower())

--- a/nmmo/systems/combat.py
+++ b/nmmo/systems/combat.py
@@ -1,153 +1,155 @@
 #Various utilities for managing combat, including hit/damage
-# pylint: disable=all
 
 import numpy as np
 
 from nmmo.systems import skill as Skill
 
 def level(skills):
-    return max(e.level.val for e in skills.skills)
+  return max(e.level.val for e in skills.skills)
 
 def damage_multiplier(config, skill, targ):
-    skills = [targ.skills.melee, targ.skills.range, targ.skills.mage]
-    exp    = [s.exp for s in skills]
+  skills = [targ.skills.melee, targ.skills.range, targ.skills.mage]
+  exp    = [s.exp for s in skills]
 
-    if max(exp) == min(exp):
-        return 1.0
-
-    idx    = np.argmax([exp])
-    targ   = skills[idx]
-
-    if type(skill) == targ.weakness:
-        return config.COMBAT_WEAKNESS_MULTIPLIER
-
+  if max(exp) == min(exp):
     return 1.0
 
-def attack(realm, player, target, skillFn):
-    config       = player.config
-    skill        = skillFn(player)
-    skill_type   = type(skill)
-    skill_name   = skill_type.__name__
+  idx    = np.argmax([exp])
+  targ   = skills[idx]
 
-    # Per-style offense/defense
-    level_damage = 0
-    if skill_type == Skill.Melee:
-        base_damage  = config.COMBAT_MELEE_DAMAGE
+  if isinstance(skill, targ.weakness):
+    return config.COMBAT_WEAKNESS_MULTIPLIER
 
-        if config.PROGRESSION_SYSTEM_ENABLED:
-            base_damage  = config.PROGRESSION_MELEE_BASE_DAMAGE
-            level_damage = config.PROGRESSION_MELEE_LEVEL_DAMAGE
+  return 1.0
 
-        offense_fn   = lambda e: e.melee_attack
-        defense_fn   = lambda e: e.melee_defense
-    elif skill_type == Skill.Range:
-        base_damage  = config.COMBAT_RANGE_DAMAGE
+# pylint: disable=unnecessary-lambda-assignment
+def attack(realm, player, target, skill_fn):
+  config       = player.config
+  skill        = skill_fn(player)
+  skill_type   = type(skill)
+  skill_name   = skill_type.__name__
 
-        if config.PROGRESSION_SYSTEM_ENABLED:
-            base_damage  = config.PROGRESSION_RANGE_BASE_DAMAGE
-            level_damage = config.PROGRESSION_RANGE_LEVEL_DAMAGE
-
-        offense_fn   = lambda e: e.range_attack
-        defense_fn   = lambda e: e.range_defense
-    elif skill_type == Skill.Mage:
-        base_damage  = config.COMBAT_MAGE_DAMAGE
-
-        if config.PROGRESSION_SYSTEM_ENABLED:
-            base_damage  = config.PROGRESSION_MAGE_BASE_DAMAGE
-            level_damage = config.PROGRESSION_MAGE_LEVEL_DAMAGE
-
-        offense_fn   = lambda e: e.mage_attack
-        defense_fn   = lambda e: e.mage_defense
-    elif __debug__:
-        assert False, 'Attack skill must be Melee, Range, or Mage'
-
-    # Compute modifiers
-    multiplier        = damage_multiplier(config, skill, target)
-    skill_offense     = base_damage + level_damage * skill.level.val
+  # Per-style offense/defense
+  level_damage = 0
+  if skill_type == Skill.Melee:
+    base_damage  = config.COMBAT_MELEE_DAMAGE
 
     if config.PROGRESSION_SYSTEM_ENABLED:
-        skill_defense     = config.PROGRESSION_BASE_DEFENSE  + \
-            config.PROGRESSION_LEVEL_DEFENSE*level(target.skills)
-    else:
-        skill_defense     = 0
+      base_damage  = config.PROGRESSION_MELEE_BASE_DAMAGE
+      level_damage = config.PROGRESSION_MELEE_LEVEL_DAMAGE
 
-    if config.EQUIPMENT_SYSTEM_ENABLED:
-        equipment_offense = player.equipment.total(offense_fn)
-        equipment_defense = target.equipment.total(defense_fn)
+    offense_fn   = lambda e: e.melee_attack
+    defense_fn   = lambda e: e.melee_defense
 
-        # for debug
-        equipment_level_offense = player.equipment.total(lambda e: e.level)
-        equipment_level_defense = target.equipment.total(lambda e: e.level)
+  elif skill_type == Skill.Range:
+    base_damage  = config.COMBAT_RANGE_DAMAGE
 
-        # after tallying ammo damage, consume ammo (i.e., fire)
-        ammunition = player.equipment.ammunition.item
-        if ammunition is not None:
-            ammunition.fire(player)
+    if config.PROGRESSION_SYSTEM_ENABLED:
+      base_damage  = config.PROGRESSION_RANGE_BASE_DAMAGE
+      level_damage = config.PROGRESSION_RANGE_LEVEL_DAMAGE
 
-    else:
-        equipment_offense = 0
-        equipment_defense = 0
+    offense_fn   = lambda e: e.range_attack
+    defense_fn   = lambda e: e.range_defense
 
-    # Total damage calculation
-    offense = skill_offense + equipment_offense
-    defense = skill_defense + equipment_defense
-    damage  = config.COMBAT_DAMAGE_FORMULA(offense, defense, multiplier)
-    #damage  = multiplier * (offense - defense)
-    damage  = max(int(damage), 0)
+  elif skill_type == Skill.Mage:
+    base_damage  = config.COMBAT_MAGE_DAMAGE
 
-    if player.is_player:
-        realm.log_milestone(f'Damage_{skill_name}', damage,
-                            f'COMBAT: Inflicted {damage} {skill_name} damage ' +
-                            f'(attack equip lvl {equipment_level_offense} vs ' +
-                            f'defense equip lvl {equipment_level_defense})',
-                            tags={"player_id": player.ent_id})
+    if config.PROGRESSION_SYSTEM_ENABLED:
+      base_damage  = config.PROGRESSION_MAGE_BASE_DAMAGE
+      level_damage = config.PROGRESSION_MAGE_LEVEL_DAMAGE
 
-    player.apply_damage(damage, skill.__class__.__name__.lower())
-    target.receive_damage(player, damage)
+    offense_fn   = lambda e: e.mage_attack
+    defense_fn   = lambda e: e.mage_defense
 
-    return damage
+  elif __debug__:
+    assert False, 'Attack skill must be Melee, Range, or Mage'
+
+  # Compute modifiers
+  multiplier        = damage_multiplier(config, skill, target)
+  skill_offense     = base_damage + level_damage * skill.level.val
+
+  if config.PROGRESSION_SYSTEM_ENABLED:
+    skill_defense     = config.PROGRESSION_BASE_DEFENSE  + \
+      config.PROGRESSION_LEVEL_DEFENSE*level(target.skills)
+  else:
+    skill_defense     = 0
+
+  if config.EQUIPMENT_SYSTEM_ENABLED:
+    equipment_offense = player.equipment.total(offense_fn)
+    equipment_defense = target.equipment.total(defense_fn)
+
+    # after tallying ammo damage, consume ammo (i.e., fire)
+    ammunition = player.equipment.ammunition.item
+    if ammunition is not None:
+      ammunition.fire(player)
+
+  else:
+    equipment_offense = 0
+    equipment_defense = 0
+
+  # Total damage calculation
+  offense = skill_offense + equipment_offense
+  defense = skill_defense + equipment_defense
+  damage  = config.COMBAT_DAMAGE_FORMULA(offense, defense, multiplier)
+  #damage  = multiplier * (offense - defense)
+  damage  = max(int(damage), 0)
+
+  if player.is_player:
+    equipment_level_offense = player.equipment.total(lambda e: e.level)
+    equipment_level_defense = target.equipment.total(lambda e: e.level)
+
+    realm.log_milestone(f'Damage_{skill_name}', damage,
+                        f'COMBAT: Inflicted {damage} {skill_name} damage ' +
+                        f'(attack equip lvl {equipment_level_offense} vs ' +
+                        f'defense equip lvl {equipment_level_defense})',
+                        tags={"player_id": player.ent_id})
+
+  player.apply_damage(damage, skill.__class__.__name__.lower())
+  target.receive_damage(player, damage)
+
+  return damage
 
 
 def danger(config, pos):
-   border = config.MAP_BORDER
-   center = config.MAP_CENTER
-   r, c   = pos
+  border = config.MAP_BORDER
+  center = config.MAP_CENTER
+  r, c   = pos
 
-   #Distance from border
-   rDist  = min(r - border, center + border - r - 1)
-   cDist  = min(c - border, center + border - c - 1)
-   dist   = min(rDist, cDist)
-   norm   = 2 * dist / center
+  #Distance from border
+  r_dist  = min(r - border, center + border - r - 1)
+  c_dist  = min(c - border, center + border - c - 1)
+  dist   = min(r_dist, c_dist)
+  norm   = 2 * dist / center
 
-   return norm
+  return norm
 
 def spawn(config, dnger):
-    border = config.MAP_BORDER
-    center = config.MAP_CENTER
-    mid    = center // 2
+  border = config.MAP_BORDER
+  center = config.MAP_CENTER
+  mid    = center // 2
 
-    dist       = dnger * center / 2
-    max_offset = mid - dist
-    offset     = mid + border + np.random.randint(-max_offset, max_offset)
+  dist       = dnger * center / 2
+  max_offset = mid - dist
+  offset     = mid + border + np.random.randint(-max_offset, max_offset)
 
-    rng = np.random.rand()
-    if rng < 0.25:
-        r = border + dist
-        c = offset
-    elif rng < 0.5:
-        r = border + center - dist - 1
-        c = offset
-    elif rng < 0.75:
-        c = border + dist
-        r = offset
-    else:
-        c = border + center - dist - 1
-        r = offset
+  rng = np.random.rand()
+  if rng < 0.25:
+    r = border + dist
+    c = offset
+  elif rng < 0.5:
+    r = border + center - dist - 1
+    c = offset
+  elif rng < 0.75:
+    c = border + dist
+    r = offset
+  else:
+    c = border + center - dist - 1
+    r = offset
 
-    if __debug__:
-        assert dnger == danger(config, (r,c)), 'Agent spawned at incorrect radius'
+  if __debug__:
+    assert dnger == danger(config, (r,c)), 'Agent spawned at incorrect radius'
 
-    r = int(r)
-    c = int(c)
+  r = int(r)
+  c = int(c)
 
-    return r, c
+  return r, c

--- a/nmmo/systems/exchange.py
+++ b/nmmo/systems/exchange.py
@@ -143,4 +143,4 @@ class Exchange:
         'supply': supply
       }
 
-      return packet
+    return packet

--- a/nmmo/systems/inventory.py
+++ b/nmmo/systems/inventory.py
@@ -110,6 +110,9 @@ class Inventory:
   def space(self):
     return self.capacity - len(self.items)
 
+  def has_stack(self, signature: Tuple) -> bool:
+    return signature in self._item_stacks
+
   def packet(self):
     item_packet = []
     if self.config.ITEM_SYSTEM_ENABLED:
@@ -132,7 +135,7 @@ class Inventory:
 
     if isinstance(item, Item.Stack):
       signature = item.signature
-      if signature in self._item_stacks:
+      if self.has_stack(signature):
         stack = self._item_stacks[signature]
         assert item.level.val == stack.level.val, f'{item} stack level mismatch'
         stack.quantity.increment(item.quantity.val)
@@ -170,7 +173,7 @@ class Inventory:
     if isinstance(item, Item.Stack):
       signature = item.signature
 
-      assert item.signature in self._item_stacks, f'{item} stack to remove not in inventory'
+      assert self.has_stack(item.signature), f'{item} stack to remove not in inventory'
       stack = self._item_stacks[signature]
 
       if quantity is None or stack.quantity.val == quantity:

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -188,11 +188,9 @@ class Equipment(Item):
     raise NotImplementedError
 
   def use(self, entity):
-    if self.listed_price > 0: # cannot use if listed for sale
-      return
-
-    if self._level(entity) < self.level.val:
-      return
+    assert self in entity.inventory, "Item is not in entity's inventory"
+    assert self.listed_price == 0, "Listed item cannot be used"
+    assert self._level(entity) >= self.level.val, "Entity's level is not sufficient to use the item"
 
     if self.equipped.val:
       self.unequip(self._slot(entity))
@@ -368,11 +366,9 @@ class Shard(Ammunition):
 #   so each item takes 1 inventory space
 class Consumable(Item):
   def use(self, entity) -> bool:
-    if self.listed_price > 0: # cannot use if listed for sale
-      return False
-
-    if self._level(entity) < self.level.val:
-      return False
+    assert self in entity.inventory, "Item is not in entity's inventory"
+    assert self.listed_price == 0, "Listed item cannot be used"
+    assert self._level(entity) >= self.level.val, "Entity's level is not sufficient to use the item"
 
     self.realm.log_milestone(
       f'Consumed_{self.__class__.__name__}', self.level.val,

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -128,6 +128,9 @@ class Item(ItemState):
     # weapons and tools must override this with specific skills
     return entity.level
 
+  def level_gt(self, entity):
+    return self.level.val > self._level(entity)
+
   def use(self, entity) -> bool:
     raise NotImplementedError
 

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -123,6 +123,11 @@ class Item(ItemState):
             'resource_restore': self.resource_restore.val,
             }
 
+  def _level(self, entity):
+    # this is for armors, ration, and poultice
+    # weapons and tools must override this with specific skills
+    return entity.level
+
   def use(self, entity) -> bool:
     raise NotImplementedError
 
@@ -182,11 +187,11 @@ class Equipment(Item):
   def _slot(self, entity):
     raise NotImplementedError
 
-  def _level(self, entity):
-    return entity.attack_level
-
   def use(self, entity):
     if self.listed_price > 0: # cannot use if listed for sale
+      return
+
+    if self._level(entity) < self.level.val:
       return
 
     if self.equipped.val:
@@ -304,8 +309,8 @@ class Ammunition(Equipment, Stack):
     return entity.inventory.equipment.ammunition
 
   def fire(self, entity) -> int:
-    if __debug__:
-      assert self.quantity.val > 0, 'Used ammunition with 0 quantity'
+    assert self.equipped.val > 0, 'Ammunition not equipped'
+    assert self.quantity.val > 0, 'Used ammunition with 0 quantity'
 
     self.quantity.decrement()
 
@@ -379,9 +384,6 @@ class Consumable(Item):
     entity.inventory.remove(self)
     self.destroy()
     return True
-
-  def _level(self, entity):
-    return entity.level
 
 class Ration(Consumable):
   ITEM_TYPE_ID = 16

--- a/scripted/behavior.py
+++ b/scripted/behavior.py
@@ -46,7 +46,7 @@ def hunt(realm, actions, entity):
 
 def attack(realm, actions, entity):
    distance = utils.distance(entity, entity.target)
-   if distance > entity.skills.style.attackRange(realm.config):
+   if distance > entity.skills.style.attack_range(realm.config):
       return
 
    actions[nmmo.action.Attack] = {nmmo.action.Style: entity.skills.style,

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -23,7 +23,7 @@ class TestAmmoUse(unittest.TestCase):
     cls.config.PLAYERS = [baselines.Melee, baselines.Range, baselines.Mage]
     cls.config.PLAYER_N = 3
     cls.config.IMMORTAL = True
-    
+
     # detailed logging for debugging
     cls.config.LOG_VERBOSE = False
     if cls.config.LOG_VERBOSE:
@@ -54,12 +54,12 @@ class TestAmmoUse(unittest.TestCase):
   def _provide_item(self, realm, ent_id, item, level, quantity):
     realm.players[ent_id].inventory.receive(
       item(realm, level=level, quantity=quantity))
-    
+
   def _setup_env(self):
     """ set up a new env and perform initial checks """
     env = ScriptedAgentTestEnv(self.config, seed=RANDOM_SEED)
     env.reset()
-    
+
     for ent_id, pos in self.spawn_locs.items():
       self._change_spawn_pos(env.realm, ent_id, pos)
       env.realm.players[ent_id].gold.update(5)

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -8,6 +8,7 @@ from scripted import baselines
 from nmmo.io import action
 from nmmo.systems import item as Item
 from nmmo.systems.item import ItemState
+from nmmo.entity.entity import EntityState
 
 TEST_HORIZON = 150
 RANDOM_SEED = 985
@@ -30,16 +31,25 @@ class TestAmmoUse(unittest.TestCase):
 
     # set up agents to test ammo use
     cls.policy = { 1:'Melee', 2:'Range', 3:'Mage' }
-    cls.spawn_locs = { 1:(17, 17), 2:(17, 19), 3:(19, 19) }
+    # 1 cannot hit 3, 2 can hit 1, 3 cannot hit 2
+    cls.spawn_locs = { 1:(17, 17), 2:(17, 19), 3:(21, 21) }
     cls.ammo = { 1:Item.Scrap, 2:Item.Shaving, 3:Item.Shard }
     cls.ammo_quantity = 2
+
+    # items to provide
+    cls.item_sig = {}
+    for ent_id in cls.policy:
+      cls.item_sig[ent_id] = []
+      for item in [cls.ammo[ent_id], Item.Top, Item.Gloves, Item.Ration, Item.Poultice]:
+        for lvl in [0, 3]:
+          cls.item_sig[ent_id].append((item, lvl))
 
   def _change_spawn_pos(self, realm, ent_id, pos):
     # check if the position is valid
     assert realm.map.tiles[pos].habitable, "Given pos is not habitable."
     realm.players[ent_id].row.update(pos[0])
     realm.players[ent_id].col.update(pos[1])
-    realm.players[ent_id].spawn_pos
+    realm.players[ent_id].spawn_pos = pos
 
   def _provide_item(self, realm, ent_id, item, level, quantity):
     realm.players[ent_id].inventory.receive(
@@ -49,9 +59,15 @@ class TestAmmoUse(unittest.TestCase):
     """ set up a new env and perform initial checks """
     env = ScriptedAgentTestEnv(self.config, seed=RANDOM_SEED)
     env.reset()
+    
     for ent_id, pos in self.spawn_locs.items():
       self._change_spawn_pos(env.realm, ent_id, pos)
-      self._provide_item(env.realm, ent_id, self.ammo[ent_id], 0, self.ammo_quantity)
+      env.realm.players[ent_id].gold.update(5)
+      for item_sig in self.item_sig[ent_id]:
+        if item_sig[0] == self.ammo[ent_id]:
+          self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], self.ammo_quantity)
+        else:
+          self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
     env.obs = env._compute_observations()
 
     # check if the agents are in specified positions
@@ -64,33 +80,85 @@ class TestAmmoUse(unittest.TestCase):
         self.assertTrue(other in env.obs[ent_id].entities.ids)
 
       # ammo instances are in the datastore and global item registry (realm)
-      item_id = ItemState.parse_array(env.obs[ent_id].inventory.values[0]).id
-      self.assertTrue(ItemState.Query.by_id(env.realm.datastore, item_id) is not None)
-      self.assertTrue(item_id in env.realm.items)
+      inventory = env.obs[ent_id].inventory
+      self.assertTrue(inventory.len == len(self.item_sig[ent_id]))
+      for inv_idx in range(inventory.len):
+        item_id = inventory.id(inv_idx)
+        self.assertTrue(ItemState.Query.by_id(env.realm.datastore, item_id) is not None)
+        self.assertTrue(item_id in env.realm.items)
 
       # agents have ammo
-      self.assertEqual(self.ammo[ent_id].ITEM_TYPE_ID,
-        ItemState.parse_array(env.obs[ent_id].inventory.values[0]).type_id)
-      self.assertEqual(self.ammo_quantity, # provided 2 ammos
-        ItemState.parse_array(env.obs[ent_id].inventory.values[0]).quantity)
+      for lvl in [0, 3]:
+        inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, lvl)
+        self.assertTrue(inv_idx is not None)
+        self.assertEqual(self.ammo_quantity, # provided 2 ammos
+          ItemState.parse_array(inventory.values[inv_idx]).quantity)
+
+      # check ActionTargets
+      gym_obs = env.obs[ent_id].to_gym()
+      
+      # ATTACK Target mask
+      entities = env.obs[ent_id].entities.ids
+      mask = gym_obs['ActionTargets'][action.Attack][action.Target][:len(entities)] > 0
+      if ent_id == 1: 
+        self.assertTrue(2 in entities[mask])
+        self.assertTrue(3 not in entities[mask])
+      if ent_id == 2:
+        self.assertTrue(1 in entities[mask])
+        self.assertTrue(3 not in entities[mask])
+      if ent_id == 3:
+        self.assertTrue(1 not in entities[mask])
+        self.assertTrue(2 not in entities[mask])
+
+      # USE InventoryItem mask
+      inventory = env.obs[ent_id].inventory
+      mask = gym_obs['ActionTargets'][action.Use][action.InventoryItem][:inventory.len] > 0
+      for item_sig in self.item_sig[ent_id]:
+        inv_idx = inventory.sig(item_sig[0].ITEM_TYPE_ID, item_sig[1])
+        if item_sig[1] == 0:
+          # items that can be used 
+          self.assertTrue(inventory.id(inv_idx) in inventory.ids[mask])
+        else:
+          # items that are too high to use
+          self.assertTrue(inventory.id(inv_idx) not in inventory.ids[mask])
+
+      # SELL InventoryItem mask
+      mask = gym_obs['ActionTargets'][action.Sell][action.InventoryItem][:inventory.len] > 0
+      for item_sig in self.item_sig[ent_id]:
+        inv_idx = inventory.sig(item_sig[0].ITEM_TYPE_ID, item_sig[1])
+        # the agent can sell anything now
+        self.assertTrue(inventory.id(inv_idx) in inventory.ids[mask])
+
+      # BUY MarketItem mask -- there is nothing on the market, so mask should be all 0
+      market = env.obs[ent_id].market
+      mask = gym_obs['ActionTargets'][action.Buy][action.MarketItem][:market.len] > 0
+      self.assertTrue(len(market.ids[mask]) == 0)
 
     return env
 
   def test_ammo_fire_all(self):
     env = self._setup_env()
 
-    # First tick actions: USE (equip) ammo
+    # First tick actions: USE (equip) level-0 ammo
     env.step({ ent_id: { action.Use: 
-        { action.Item: ItemState.parse_array(env.obs[ent_id].inventory.values[0]).id }
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0) }
       } for ent_id in self.ammo })
 
     # check if the agents have equipped the ammo
     for ent_id in self.ammo:
+      gym_obs = env.obs[ent_id].to_gym()
+      inventory = env.obs[ent_id].inventory
+      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
       self.assertEqual(1, # True
-        ItemState.parse_array(env.obs[ent_id].inventory.values[0]).equipped)
+        ItemState.parse_array(inventory.values[inv_idx]).equipped)
+
+      # check SELL InventoryItem mask -- one cannot sell equipped item
+      mask = gym_obs['ActionTargets'][action.Sell][action.InventoryItem][:inventory.len] > 0
+      self.assertTrue(inventory.id(inv_idx) not in inventory.ids[mask])
 
     # Second tick actions: ATTACK other agents using ammo
     #  NOTE that the agents are immortal
+    #  NOTE that agents 1 & 3's attack are invalid due to out-of-range
     env.step({ ent_id: { action.Attack: 
         { action.Style: env.realm.players[ent_id].agent.style[0],
           action.Target: (ent_id+1)%3+1 } }
@@ -99,24 +167,37 @@ class TestAmmoUse(unittest.TestCase):
     # check if the ammos were consumed
     ammo_ids = []
     for ent_id in self.ammo:
-      item_info = ItemState.parse_array(env.obs[ent_id].inventory.values[0])
-      self.assertEqual(1, item_info.quantity)
-      ammo_ids.append(item_info.id)
+      inventory = env.obs[ent_id].inventory
+      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
+      item_info = ItemState.parse_array(inventory.values[inv_idx])
+      if ent_id == 2:
+        # only agent 2's attack is valid and consume ammo
+        self.assertEqual(self.ammo_quantity - 1, item_info.quantity)
+        ammo_ids.append(inventory.id(inv_idx))
+      else:
+        self.assertEqual(self.ammo_quantity, item_info.quantity)
 
-    # Third tick actions: ATTACK again to use up all the ammo
+    # Third tick actions: ATTACK again to use up all the ammo, except agent 3
+    #  NOTE that agent 3's attack command is invalid due to out-of-range
     env.step({ ent_id: { action.Attack: 
         { action.Style: env.realm.players[ent_id].agent.style[0],
           action.Target: (ent_id+1)%3+1 } }
         for ent_id in self.ammo })
 
     # check if the ammos are depleted and the ammo slot is empty
-    for ent_id in self.ammo:
-      self.assertTrue(len(env.obs[ent_id].inventory.values) ==  0) # empty inventory
-      self.assertTrue(env.realm.players[ent_id].inventory.equipment.ammunition.item == None)
+    ent_id = 2
+    self.assertTrue(env.obs[ent_id].inventory.len == len(self.item_sig[ent_id]) - 1)
+    self.assertTrue(env.realm.players[ent_id].inventory.equipment.ammunition.item == None)
 
     for item_id in ammo_ids:
       self.assertTrue(len(ItemState.Query.by_id(env.realm.datastore, item_id)) == 0)
       self.assertTrue(item_id not in env.realm.items)
+
+    # invalid attacks
+    for ent_id in [1, 3]:
+      # agent 3 gathered shaving, so the item count increased
+      #self.assertTrue(env.obs[ent_id].inventory.len == len(self.item_sig[ent_id]))
+      self.assertTrue(env.realm.players[ent_id].inventory.equipment.ammunition.item is not None)
 
     # DONE
 
@@ -125,32 +206,65 @@ class TestAmmoUse(unittest.TestCase):
 
     sell_price = 1
 
-    # First tick actions: SELL ammo
+    # provide extra scrap to range to make its inventory full
+    # but level-0 scrap overlaps with the listed item
+    ent_id = 2
+    self._provide_item(env.realm, ent_id, Item.Scrap, level=0, quantity=3)
+    self._provide_item(env.realm, ent_id, Item.Scrap, level=1, quantity=3)
+
+    # provide extra scrap to mage to make its inventory full
+    # there will be no overlapping item
+    ent_id = 3
+    self._provide_item(env.realm, ent_id, Item.Scrap, level=5, quantity=3)
+    self._provide_item(env.realm, ent_id, Item.Scrap, level=7, quantity=3)
+    env.obs = env._compute_observations()
+
+    # First tick actions: SELL level-0 ammo
     env.step({ ent_id: { action.Sell: 
-        { action.Item: ItemState.parse_array(env.obs[ent_id].inventory.values[0]).id,
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0),
           action.Price: sell_price } }
         for ent_id in self.ammo })
 
     # check if the ammos were listed
     for ent_id in self.ammo:
+      gym_obs = env.obs[ent_id].to_gym()
+      inventory = env.obs[ent_id].inventory
+      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
+      item_info = ItemState.parse_array(inventory.values[inv_idx])
       # ItemState data
-      self.assertEqual(sell_price,
-        ItemState.parse_array(env.obs[ent_id].inventory.values[0]).listed_price)
+      self.assertEqual(sell_price, item_info.listed_price)
       # Exchange listing
-      self.assertTrue(
-        ItemState.parse_array(env.obs[ent_id].inventory.values[0]).id \
-        in env.realm.exchange._item_listings
-      )
+      self.assertTrue(item_info.id in env.realm.exchange._item_listings)
+      self.assertTrue(item_info.id in env.obs[ent_id].market.ids)
+
+      # check SELL InventoryItem mask -- one cannot sell listed item
+      mask = gym_obs['ActionTargets'][action.Sell][action.InventoryItem][:inventory.len] > 0
+      self.assertTrue(inventory.id(inv_idx) not in inventory.ids[mask])
+
+      # check USE InventoryItem mask -- one cannot use listed item
+      mask = gym_obs['ActionTargets'][action.Use][action.InventoryItem][:inventory.len] > 0
+      self.assertTrue(inventory.id(inv_idx) not in inventory.ids[mask])
+
+      # check BUY MarketItem mask -- there should be two ammo items in the market
+      mask = gym_obs['ActionTargets'][action.Buy][action.MarketItem][:inventory.len] > 0
+      # agent 1 has inventory space
+      if ent_id == 1: self.assertTrue(sum(mask) == 2)
+      # agent 2's inventory is full but can buy level-0 scrap (existing ammo)
+      if ent_id == 2: self.assertTrue(sum(mask) == 1)
+      # agent 3's inventory is full without overlapping ammo
+      if ent_id == 3: self.assertTrue(sum(mask) == 0)
 
     # Second tick actions: USE ammo, which should NOT happen
     env.step({ ent_id: { action.Use: 
-        { action.Item: ItemState.parse_array(env.obs[ent_id].inventory.values[0]).id }
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0) }
       } for ent_id in self.ammo })
 
     # check if the agents have equipped the ammo
     for ent_id in self.ammo:
+      inventory = env.obs[ent_id].inventory
+      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
       self.assertEqual(0, # False
-        ItemState.parse_array(env.obs[ent_id].inventory.values[0]).equipped)
+        ItemState.parse_array(inventory.values[inv_idx]).equipped)
 
     # DONE
 
@@ -158,6 +272,9 @@ class TestAmmoUse(unittest.TestCase):
     env = self._setup_env()
 
     extra_ammo = 500
+    scrap_lvl0 = (Item.Scrap.ITEM_TYPE_ID, 0)
+    scrap_lvl1 = (Item.Scrap.ITEM_TYPE_ID, 1)
+    scrap_lvl3 = (Item.Scrap.ITEM_TYPE_ID, 3)
 
     for ent_id in self.policy:
       # provide extra scrap 
@@ -170,36 +287,78 @@ class TestAmmoUse(unittest.TestCase):
 
     # check inventory
     for ent_id in self.ammo:
-      inventory = { item.signature: item.quantity.val
-                    for item in env.realm.players[ent_id].inventory.items }
-      self.assertTrue( (Item.Scrap.ITEM_TYPE_ID, 0) in inventory )
-      self.assertTrue( (Item.Scrap.ITEM_TYPE_ID, 1) in inventory )
-      self.assertEqual( inventory[(Item.Scrap.ITEM_TYPE_ID, 1)], extra_ammo )
+      # realm data
+      inv_realm = { item.signature: item.quantity.val
+                    for item in env.realm.players[ent_id].inventory.items
+                    if isinstance(item, Item.Stack) }
+      self.assertTrue( scrap_lvl0 in inv_realm )
+      self.assertTrue( scrap_lvl1 in inv_realm )
+      self.assertEqual( inv_realm[scrap_lvl1], extra_ammo )
+
+      # item datastore
+      inv_obs = env.obs[ent_id].inventory
+      self.assertTrue(inv_obs.sig(*scrap_lvl0) is not None)
+      self.assertTrue(inv_obs.sig(*scrap_lvl1) is not None)
+      self.assertEqual( extra_ammo,
+        ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl1)]).quantity)
       if ent_id == 1:
         # if the ammo has the same signature, the quantity is added to the existing stack
-        self.assertEqual( inventory[(Item.Scrap.ITEM_TYPE_ID, 0)], extra_ammo + self.ammo_quantity )
+        self.assertEqual( inv_realm[scrap_lvl0], extra_ammo + self.ammo_quantity )
+        self.assertEqual( extra_ammo + self.ammo_quantity,
+          ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).quantity)
+        # so there should be 1 more space
+        self.assertEqual( inv_obs.len, self.config.ITEM_INVENTORY_CAPACITY - 1)
+
       else:
         # if the signature is different, it occupies a new inventory space
-        self.assertEqual( inventory[(Item.Scrap.ITEM_TYPE_ID, 0)], extra_ammo )
+        self.assertEqual( inv_realm[scrap_lvl0], extra_ammo )
+        self.assertEqual( extra_ammo,
+          ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).quantity)
+        # thus the inventory is full
+        self.assertEqual( inv_obs.len, self.config.ITEM_INVENTORY_CAPACITY)
 
-    # First tick actions: USE (equip) ammo 0
+      if ent_id == 1:
+        gym_obs = env.obs[ent_id].to_gym()
+        # check USE InventoryItem mask
+        mask = gym_obs['ActionTargets'][action.Use][action.InventoryItem][:inv_obs.len] > 0
+        # level-2 melee should be able to use level-0, level-1 scrap but not level-3
+        self.assertTrue(inv_obs.id(inv_obs.sig(*scrap_lvl0)) in inv_obs.ids[mask])
+        self.assertTrue(inv_obs.id(inv_obs.sig(*scrap_lvl1)) in inv_obs.ids[mask])
+        self.assertTrue(inv_obs.id(inv_obs.sig(*scrap_lvl3)) not in inv_obs.ids[mask])
+
+    # First tick actions: USE (equip) level-0 ammo
     #   execute only the agent 1's action
     ent_id = 1
     env.step({ ent_id: { action.Use: 
-        { action.Item: ItemState.parse_array(env.obs[ent_id].inventory.values[0]).id }}})
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(*scrap_lvl0) } }})
 
     # check if the agents have equipped the ammo 0
-    self.assertTrue(ItemState.parse_array(env.obs[ent_id].inventory.values[0]).equipped == 1)
-    self.assertTrue(ItemState.parse_array(env.obs[ent_id].inventory.values[1]).equipped == 0)
+    inv_obs = env.obs[ent_id].inventory
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).equipped == 1)
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl1)]).equipped == 0)
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl3)]).equipped == 0)
 
-    # Second tick actions: USE (equip) ammo 1
-    #   this should unequip 0 then equip 1
+    # Second tick actions: USE (equip) level-1 ammo
+    #   this should unequip level-0 then equip level-1 ammo
     env.step({ ent_id: { action.Use: 
-        { action.Item: ItemState.parse_array(env.obs[ent_id].inventory.values[1]).id }}})
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(*scrap_lvl1) } }})
 
     # check if the agents have equipped the ammo 1
-    self.assertTrue(ItemState.parse_array(env.obs[ent_id].inventory.values[0]).equipped == 0)
-    self.assertTrue(ItemState.parse_array(env.obs[ent_id].inventory.values[1]).equipped == 1)
+    inv_obs = env.obs[ent_id].inventory
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).equipped == 0)
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl1)]).equipped == 1)
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl3)]).equipped == 0)
+
+    # Third tick actions: USE (equip) level-3 ammo
+    #   this should ignore USE action and leave level-1 ammo equipped
+    env.step({ ent_id: { action.Use: 
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(*scrap_lvl3) } }})
+
+    # check if the agents have equipped the ammo 1
+    inv_obs = env.obs[ent_id].inventory
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).equipped == 0)
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl1)]).equipped == 1)
+    self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl3)]).equipped == 0)
 
     # DONE
 

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -1,4 +1,5 @@
 import unittest
+import logging
 
 # pylint: disable=import-error
 from testhelpers import ScriptedAgentTestEnv, ScriptedAgentTestConfig
@@ -11,6 +12,7 @@ from nmmo.systems.item import ItemState
 TEST_HORIZON = 150
 RANDOM_SEED = 985
 
+LOGFILE = 'tests/action/test_ammo_use.log'
 
 class TestAmmoUse(unittest.TestCase):
   @classmethod
@@ -20,6 +22,11 @@ class TestAmmoUse(unittest.TestCase):
     cls.config.PLAYERS = [baselines.Melee, baselines.Range, baselines.Mage]
     cls.config.PLAYER_N = 3
     cls.config.IMMORTAL = True
+    
+    # detailed logging for debugging
+    cls.config.LOG_VERBOSE = True
+    if cls.config.LOG_VERBOSE:
+      logging.basicConfig(filename=LOGFILE, level=logging.INFO)
 
     # set up agents to test ammo use
     cls.policy = { 1:'Melee', 2:'Range', 3:'Mage' }

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -24,7 +24,7 @@ class TestAmmoUse(unittest.TestCase):
     cls.config.IMMORTAL = True
     
     # detailed logging for debugging
-    cls.config.LOG_VERBOSE = True
+    cls.config.LOG_VERBOSE = False
     if cls.config.LOG_VERBOSE:
       logging.basicConfig(filename=LOGFILE, level=logging.INFO)
 

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -2,153 +2,40 @@ import unittest
 import logging
 
 # pylint: disable=import-error
-from testhelpers import ScriptedAgentTestEnv, ScriptedAgentTestConfig
+from testhelpers import ScriptedTestTemplate
 
-from scripted import baselines
 from nmmo.io import action
 from nmmo.systems import item as Item
 from nmmo.systems.item import ItemState
-from nmmo.entity.entity import EntityState
 
-TEST_HORIZON = 150
-RANDOM_SEED = 985
+RANDOM_SEED = 284
 
 LOGFILE = 'tests/action/test_ammo_use.log'
 
-class TestAmmoUse(unittest.TestCase):
+class TestAmmoUse(ScriptedTestTemplate):
   @classmethod
   def setUpClass(cls):
-    # only use Combat agents
-    cls.config = ScriptedAgentTestConfig()
-    cls.config.PLAYERS = [baselines.Melee, baselines.Range, baselines.Mage]
-    cls.config.PLAYER_N = 3
-    cls.config.IMMORTAL = True
+    super().setUpClass()
 
-    # detailed logging for debugging
+    # config specific to the tests here
+    cls.config.IMMORTAL = True
     cls.config.LOG_VERBOSE = False
     if cls.config.LOG_VERBOSE:
       logging.basicConfig(filename=LOGFILE, level=logging.INFO)
 
-    # set up agents to test ammo use
-    cls.policy = { 1:'Melee', 2:'Range', 3:'Mage' }
-    # 1 cannot hit 3, 2 can hit 1, 3 cannot hit 2
-    cls.spawn_locs = { 1:(17, 17), 2:(17, 19), 3:(21, 21) }
-    cls.ammo = { 1:Item.Scrap, 2:Item.Shaving, 3:Item.Shard }
-    cls.ammo_quantity = 2
-
-    # items to provide
-    cls.item_sig = {}
-    for ent_id in cls.policy:
-      cls.item_sig[ent_id] = []
-      for item in [cls.ammo[ent_id], Item.Top, Item.Gloves, Item.Ration, Item.Poultice]:
-        for lvl in [0, 3]:
-          cls.item_sig[ent_id].append((item, lvl))
-
-  def _change_spawn_pos(self, realm, ent_id, pos):
-    # check if the position is valid
-    assert realm.map.tiles[pos].habitable, "Given pos is not habitable."
-    realm.players[ent_id].row.update(pos[0])
-    realm.players[ent_id].col.update(pos[1])
-    realm.players[ent_id].spawn_pos = pos
-
-  def _provide_item(self, realm, ent_id, item, level, quantity):
-    realm.players[ent_id].inventory.receive(
-      item(realm, level=level, quantity=quantity))
-
-  def _setup_env(self):
-    """ set up a new env and perform initial checks """
-    env = ScriptedAgentTestEnv(self.config, seed=RANDOM_SEED)
-    env.reset()
-
-    for ent_id, pos in self.spawn_locs.items():
-      self._change_spawn_pos(env.realm, ent_id, pos)
-      env.realm.players[ent_id].gold.update(5)
-      for item_sig in self.item_sig[ent_id]:
-        if item_sig[0] == self.ammo[ent_id]:
-          self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], self.ammo_quantity)
-        else:
-          self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
-    env.obs = env._compute_observations()
-
-    # check if the agents are in specified positions
-    for ent_id, pos in self.spawn_locs.items():
-      self.assertEqual(env.realm.players[ent_id].policy, self.policy[ent_id])
-      self.assertEqual(env.realm.players[ent_id].pos, pos)
-
-      # agents see each other
-      for other, pos in self.spawn_locs.items():
-        self.assertTrue(other in env.obs[ent_id].entities.ids)
-
-      # ammo instances are in the datastore and global item registry (realm)
-      inventory = env.obs[ent_id].inventory
-      self.assertTrue(inventory.len == len(self.item_sig[ent_id]))
-      for inv_idx in range(inventory.len):
-        item_id = inventory.id(inv_idx)
-        self.assertTrue(ItemState.Query.by_id(env.realm.datastore, item_id) is not None)
-        self.assertTrue(item_id in env.realm.items)
-
-      # agents have ammo
-      for lvl in [0, 3]:
-        inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, lvl)
-        self.assertTrue(inv_idx is not None)
-        self.assertEqual(self.ammo_quantity, # provided 2 ammos
-          ItemState.parse_array(inventory.values[inv_idx]).quantity)
-
-      # check ActionTargets
-      gym_obs = env.obs[ent_id].to_gym()
-      
-      # ATTACK Target mask
-      entities = env.obs[ent_id].entities.ids
-      mask = gym_obs['ActionTargets'][action.Attack][action.Target][:len(entities)] > 0
-      if ent_id == 1: 
-        self.assertTrue(2 in entities[mask])
-        self.assertTrue(3 not in entities[mask])
-      if ent_id == 2:
-        self.assertTrue(1 in entities[mask])
-        self.assertTrue(3 not in entities[mask])
-      if ent_id == 3:
-        self.assertTrue(1 not in entities[mask])
-        self.assertTrue(2 not in entities[mask])
-
-      # USE InventoryItem mask
-      inventory = env.obs[ent_id].inventory
-      mask = gym_obs['ActionTargets'][action.Use][action.InventoryItem][:inventory.len] > 0
-      for item_sig in self.item_sig[ent_id]:
-        inv_idx = inventory.sig(item_sig[0].ITEM_TYPE_ID, item_sig[1])
-        if item_sig[1] == 0:
-          # items that can be used 
-          self.assertTrue(inventory.id(inv_idx) in inventory.ids[mask])
-        else:
-          # items that are too high to use
-          self.assertTrue(inventory.id(inv_idx) not in inventory.ids[mask])
-
-      # SELL InventoryItem mask
-      mask = gym_obs['ActionTargets'][action.Sell][action.InventoryItem][:inventory.len] > 0
-      for item_sig in self.item_sig[ent_id]:
-        inv_idx = inventory.sig(item_sig[0].ITEM_TYPE_ID, item_sig[1])
-        # the agent can sell anything now
-        self.assertTrue(inventory.id(inv_idx) in inventory.ids[mask])
-
-      # BUY MarketItem mask -- there is nothing on the market, so mask should be all 0
-      market = env.obs[ent_id].market
-      mask = gym_obs['ActionTargets'][action.Buy][action.MarketItem][:market.len] > 0
-      self.assertTrue(len(market.ids[mask]) == 0)
-
-    return env
-
   def test_ammo_fire_all(self):
-    env = self._setup_env()
+    env = self._setup_env(random_seed=RANDOM_SEED)
 
     # First tick actions: USE (equip) level-0 ammo
     env.step({ ent_id: { action.Use: 
-        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0) }
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id], 0) }
       } for ent_id in self.ammo })
 
     # check if the agents have equipped the ammo
     for ent_id in self.ammo:
       gym_obs = env.obs[ent_id].to_gym()
       inventory = env.obs[ent_id].inventory
-      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
+      inv_idx = inventory.sig(self.ammo[ent_id], 0)
       self.assertEqual(1, # True
         ItemState.parse_array(inventory.values[inv_idx]).equipped)
 
@@ -168,7 +55,7 @@ class TestAmmoUse(unittest.TestCase):
     ammo_ids = []
     for ent_id in self.ammo:
       inventory = env.obs[ent_id].inventory
-      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
+      inv_idx = inventory.sig(self.ammo[ent_id], 0)
       item_info = ItemState.parse_array(inventory.values[inv_idx])
       if ent_id == 2:
         # only agent 2's attack is valid and consume ammo
@@ -202,7 +89,7 @@ class TestAmmoUse(unittest.TestCase):
     # DONE
 
   def test_cannot_use_listed_items(self):
-    env = self._setup_env()
+    env = self._setup_env(random_seed=RANDOM_SEED)
 
     sell_price = 1
 
@@ -221,7 +108,7 @@ class TestAmmoUse(unittest.TestCase):
 
     # First tick actions: SELL level-0 ammo
     env.step({ ent_id: { action.Sell: 
-        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0),
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id], 0),
           action.Price: sell_price } }
         for ent_id in self.ammo })
 
@@ -229,7 +116,7 @@ class TestAmmoUse(unittest.TestCase):
     for ent_id in self.ammo:
       gym_obs = env.obs[ent_id].to_gym()
       inventory = env.obs[ent_id].inventory
-      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
+      inv_idx = inventory.sig(self.ammo[ent_id], 0)
       item_info = ItemState.parse_array(inventory.values[inv_idx])
       # ItemState data
       self.assertEqual(sell_price, item_info.listed_price)
@@ -256,25 +143,26 @@ class TestAmmoUse(unittest.TestCase):
 
     # Second tick actions: USE ammo, which should NOT happen
     env.step({ ent_id: { action.Use: 
-        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0) }
+        { action.InventoryItem: env.obs[ent_id].inventory.sig(self.ammo[ent_id], 0) }
       } for ent_id in self.ammo })
 
     # check if the agents have equipped the ammo
     for ent_id in self.ammo:
       inventory = env.obs[ent_id].inventory
-      inv_idx = inventory.sig(self.ammo[ent_id].ITEM_TYPE_ID, 0)
+      inv_idx = inventory.sig(self.ammo[ent_id], 0)
       self.assertEqual(0, # False
         ItemState.parse_array(inventory.values[inv_idx]).equipped)
 
     # DONE
 
   def test_receive_extra_ammo_swap(self):
-    env = self._setup_env()
+    env = self._setup_env(random_seed=RANDOM_SEED)
 
     extra_ammo = 500
-    scrap_lvl0 = (Item.Scrap.ITEM_TYPE_ID, 0)
-    scrap_lvl1 = (Item.Scrap.ITEM_TYPE_ID, 1)
-    scrap_lvl3 = (Item.Scrap.ITEM_TYPE_ID, 3)
+    scrap_lvl0 = (Item.Scrap, 0)
+    scrap_lvl1 = (Item.Scrap, 1)
+    scrap_lvl3 = (Item.Scrap, 3)
+    sig_int_tuple = lambda sig: (sig[0].ITEM_TYPE_ID, sig[1])
 
     for ent_id in self.policy:
       # provide extra scrap 
@@ -291,9 +179,9 @@ class TestAmmoUse(unittest.TestCase):
       inv_realm = { item.signature: item.quantity.val
                     for item in env.realm.players[ent_id].inventory.items
                     if isinstance(item, Item.Stack) }
-      self.assertTrue( scrap_lvl0 in inv_realm )
-      self.assertTrue( scrap_lvl1 in inv_realm )
-      self.assertEqual( inv_realm[scrap_lvl1], extra_ammo )
+      self.assertTrue( sig_int_tuple(scrap_lvl0) in inv_realm )
+      self.assertTrue( sig_int_tuple(scrap_lvl1) in inv_realm )
+      self.assertEqual( inv_realm[sig_int_tuple(scrap_lvl1)], extra_ammo )
 
       # item datastore
       inv_obs = env.obs[ent_id].inventory
@@ -303,7 +191,7 @@ class TestAmmoUse(unittest.TestCase):
         ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl1)]).quantity)
       if ent_id == 1:
         # if the ammo has the same signature, the quantity is added to the existing stack
-        self.assertEqual( inv_realm[scrap_lvl0], extra_ammo + self.ammo_quantity )
+        self.assertEqual( inv_realm[sig_int_tuple(scrap_lvl0)], extra_ammo + self.ammo_quantity )
         self.assertEqual( extra_ammo + self.ammo_quantity,
           ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).quantity)
         # so there should be 1 more space
@@ -311,7 +199,7 @@ class TestAmmoUse(unittest.TestCase):
 
       else:
         # if the signature is different, it occupies a new inventory space
-        self.assertEqual( inv_realm[scrap_lvl0], extra_ammo )
+        self.assertEqual( inv_realm[sig_int_tuple(scrap_lvl0)], extra_ammo )
         self.assertEqual( extra_ammo,
           ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).quantity)
         # thus the inventory is full
@@ -359,6 +247,79 @@ class TestAmmoUse(unittest.TestCase):
     self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl0)]).equipped == 0)
     self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl1)]).equipped == 1)
     self.assertTrue(ItemState.parse_array(inv_obs.values[inv_obs.sig(*scrap_lvl3)]).equipped == 0)
+
+    # DONE
+
+  def test_use_ration_poultice(self):
+    # cannot use level-3 ration & poultice due to low level
+    # can use level-0 ration & poultice to increase food/water/health
+    env = self._setup_env(random_seed=RANDOM_SEED)
+
+    # make food/water/health 20
+    res_dec_tick = env.config.RESOURCE_DEPLETION_RATE
+    init_res = 20
+    for ent_id in self.policy:
+      env.realm.players[ent_id].resources.food.update(init_res)
+      env.realm.players[ent_id].resources.water.update(init_res)
+      env.realm.players[ent_id].resources.health.update(init_res)
+    env.obs = env._compute_observations()
+
+    """First tick: try to use level-3 ration & poultice"""
+    ration_lvl3 = (Item.Ration, 3)
+    poultice_lvl3 = (Item.Poultice, 3)
+    
+    actions = {}
+    ent_id = 1; actions[ent_id] = { action.Use:
+      { action.InventoryItem: env.obs[ent_id].inventory.sig(*ration_lvl3) } }
+    ent_id = 2; actions[ent_id] = { action.Use:
+      { action.InventoryItem: env.obs[ent_id].inventory.sig(*ration_lvl3) } }
+    ent_id = 3; actions[ent_id] = { action.Use:
+      { action.InventoryItem: env.obs[ent_id].inventory.sig(*poultice_lvl3) } }
+
+    env.step(actions)
+
+    # check if the agents have used the ration & poultice
+    for ent_id in [1, 2]:
+      # cannot use due to low level, so still in the inventory
+      self.assertFalse( env.obs[ent_id].inventory.sig(*ration_lvl3) is None)
+
+      # failed to restore food/water, so no change
+      resources = env.realm.players[ent_id].resources
+      self.assertEqual( resources.food.val, init_res - res_dec_tick)
+      self.assertEqual( resources.water.val, init_res - res_dec_tick)
+    
+    ent_id = 3 # failed to use the item
+    self.assertFalse( env.obs[ent_id].inventory.sig(*poultice_lvl3) is None)
+    self.assertEqual( env.realm.players[ent_id].resources.health.val, init_res)
+
+    """Second tick: try to use level-0 ration & poultice"""
+    ration_lvl0 = (Item.Ration, 0)
+    poultice_lvl0 = (Item.Poultice, 0)
+    
+    actions = {}
+    ent_id = 1; actions[ent_id] = { action.Use:
+      { action.InventoryItem: env.obs[ent_id].inventory.sig(*ration_lvl0) } }
+    ent_id = 2; actions[ent_id] = { action.Use:
+      { action.InventoryItem: env.obs[ent_id].inventory.sig(*ration_lvl0) } }
+    ent_id = 3; actions[ent_id] = { action.Use:
+      { action.InventoryItem: env.obs[ent_id].inventory.sig(*poultice_lvl0) } }
+
+    env.step(actions)
+
+    # check if the agents have successfully used the ration & poultice
+    restore = env.config.PROFESSION_CONSUMABLE_RESTORE(0)
+    for ent_id in [1, 2]:
+      # items should be gone
+      self.assertTrue( env.obs[ent_id].inventory.sig(*ration_lvl0) is None)
+
+      # successfully restored food/water
+      resources = env.realm.players[ent_id].resources
+      self.assertEqual( resources.food.val, init_res + restore - 2*res_dec_tick)
+      self.assertEqual( resources.water.val, init_res + restore - 2*res_dec_tick)
+    
+    ent_id = 3 # successfully restored health
+    self.assertTrue( env.obs[ent_id].inventory.sig(*poultice_lvl0) is None) # item gone
+    self.assertEqual( env.realm.players[ent_id].resources.health.val, init_res + restore)
 
     # DONE
 

--- a/tests/action/test_destroy_give_gold.py
+++ b/tests/action/test_destroy_give_gold.py
@@ -1,0 +1,296 @@
+import unittest
+import logging
+
+# pylint: disable=import-error
+from testhelpers import ScriptedTestTemplate
+
+from nmmo.io import action
+from nmmo.systems import item as Item
+from nmmo.systems.item import ItemState
+from scripted import baselines
+
+RANDOM_SEED = 985
+
+LOGFILE = 'tests/action/test_destroy_give_gold.log'
+
+class TestDestroyGiveGold(ScriptedTestTemplate):
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+
+    # config specific to the tests here
+    cls.config.PLAYERS = [baselines.Melee, baselines.Range]
+    cls.config.PLAYER_N = 6
+
+    cls.policy = { 1:'Melee', 2:'Range', 3:'Melee', 4:'Range', 5:'Melee', 6:'Range' }
+    cls.spawn_locs = { 1:(17,17), 2:(21,21), 3:(17,17), 4:(21,21), 5:(21,21), 6:(17,17) }
+    cls.ammo = { 1:Item.Scrap, 2:Item.Shaving, 3:Item.Scrap, 
+                 4:Item.Shaving, 5:Item.Scrap, 6:Item.Shaving }
+
+    cls.config.LOG_VERBOSE = False
+    if cls.config.LOG_VERBOSE:
+      logging.basicConfig(filename=LOGFILE, level=logging.INFO)
+
+  def test_destroy(self):
+    env = self._setup_env(random_seed=RANDOM_SEED)
+
+    # check if level-0 and level-3 ammo are in the correct place
+    for ent_id in self.policy:
+      for idx, lvl in enumerate(self.item_level):
+        assert self.item_sig[ent_id][idx] == (self.ammo[ent_id], lvl)
+
+    # equipped items cannot be destroyed, i.e. that action will be ignored
+    # this should be marked in the mask too
+
+    """ First tick """ # First tick actions: USE (equip) level-0 ammo
+    env.step({ ent_id: { action.Use: { action.InventoryItem: 
+        env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][0]) } # level-0 ammo
+      } for ent_id in self.policy })
+    
+    # check if the agents have equipped the ammo
+    for ent_id in self.policy:
+      ent_obs = env.obs[ent_id]
+      inv_idx = ent_obs.inventory.sig(*self.item_sig[ent_id][0]) # level-0 ammo
+      self.assertEqual(1, # True
+        ItemState.parse_array(ent_obs.inventory.values[inv_idx]).equipped)
+
+      # check Destroy InventoryItem mask -- one cannot destroy equipped item
+      for item_sig in self.item_sig[ent_id]:
+        if item_sig == (self.ammo[ent_id], 0): # level-0 ammo
+          self.assertFalse(self._check_inv_mask(ent_obs, action.Destroy, item_sig))
+        else:
+          # other items can be destroyed
+          self.assertTrue(self._check_inv_mask(ent_obs, action.Destroy, item_sig))
+
+    """ Second tick """ # Second tick actions: DESTROY ammo
+    actions = {}
+    
+    for ent_id in self.policy:
+      if ent_id in [1, 2]:
+        # agent 1 & 2, destroy the level-3 ammos, which are valid
+        actions[ent_id] = { action.Destroy: 
+          { action.InventoryItem: env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][1]) } }
+      else:
+        # other agents: destroy the equipped level-0 ammos, which are invalid
+        actions[ent_id] = { action.Destroy: 
+          { action.InventoryItem: env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][0]) } }
+    env.step(actions)
+
+    # check if the ammos were destroyed
+    for ent_id in self.policy:
+      if ent_id in [1, 2]:
+        inv_idx = env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][1])
+        self.assertTrue(inv_idx is None) # valid actions, thus destroyed
+      else:
+        inv_idx = env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][0])
+        self.assertTrue(inv_idx is not None) # invalid actions, thus not destroyed
+
+    # DONE
+
+  def test_give_team_tile_npc(self):
+    # cannot give to self (should be masked)
+    # cannot give if not on the same tile (should be masked)
+    # cannot give to the other team member (should be masked)
+    # cannot give to npc (should be masked)
+    env = self._setup_env(random_seed=RANDOM_SEED)
+
+    # teleport the npc -1 to agent 5's location
+    self._change_spawn_pos(env.realm, -1, self.spawn_locs[5])
+    env.obs = env._compute_observations()
+
+    """ First tick actions """
+    actions = {}
+    test_cond = {}
+
+    # agent 1: give ammo to agent 3 (valid: the same team, same tile)
+    test_cond[1] = { 'tgt_id': 3, 'item_sig': self.item_sig[1][0],
+                     'ent_mask': True, 'inv_mask': True, 'valid': True }
+    # agent 2: give ammo to agent 2 (invalid: cannot give to self)
+    test_cond[2] = { 'tgt_id': 2, 'item_sig': self.item_sig[2][0],
+                     'ent_mask': False, 'inv_mask': True, 'valid': False }
+    # agent 3: give ammo to agent 6 (invalid: the same tile but other team)
+    test_cond[3] = { 'tgt_id': 6, 'item_sig': self.item_sig[3][0],
+                     'ent_mask': False, 'inv_mask': True, 'valid': False }
+    # agent 4: give ammo to agent 5 (invalid: the same team but other tile)
+    test_cond[4] = { 'tgt_id': 5, 'item_sig': self.item_sig[4][0],
+                     'ent_mask': False, 'inv_mask': True, 'valid': False }
+    # agent 5: give ammo to npc -1 (invalid, should be masked)
+    test_cond[5] = { 'tgt_id': -1, 'item_sig': self.item_sig[5][0],
+                     'ent_mask': False, 'inv_mask': True, 'valid': False }
+
+    actions = self._check_assert_make_action(env, action.Give, test_cond)
+    env.step(actions)
+
+    # check the results
+    for ent_id, cond in test_cond.items():
+      self.assertEqual( cond['valid'],
+        env.obs[ent_id].inventory.sig(*cond['item_sig']) is None)
+      
+      if ent_id == 1: # agent 1 gave ammo stack to agent 3
+        tgt_inv = env.obs[cond['tgt_id']].inventory
+        inv_idx = tgt_inv.sig(*cond['item_sig'])
+        self.assertEqual(2 * self.ammo_quantity,
+          ItemState.parse_array(tgt_inv.values[inv_idx]).quantity)
+
+    # DONE
+
+  def test_give_equipped_listed(self):
+    # cannot give equipped items (should be masked)
+    # cannot give listed items (should be masked)
+    env = self._setup_env(random_seed=RANDOM_SEED)
+
+    """ First tick actions """
+    actions = {}
+
+    # agent 1: equip the ammo
+    ent_id = 1; item_sig = self.item_sig[ent_id][0]
+    self.assertTrue(
+      self._check_inv_mask(env.obs[ent_id], action.Use, item_sig)) 
+    actions[ent_id] = { action.Use: { action.InventoryItem: 
+        env.obs[ent_id].inventory.sig(*item_sig) } }
+
+    # agent 2: list the ammo for sale
+    ent_id = 2; price = 5; item_sig = self.item_sig[ent_id][0]
+    self.assertTrue(
+      self._check_inv_mask(env.obs[ent_id], action.Sell, item_sig)) 
+    actions[ent_id] = { action.Sell: { 
+        action.InventoryItem: env.obs[ent_id].inventory.sig(*item_sig),
+        action.Price: price } }
+
+    env.step(actions)
+
+    # Check the first tick actions
+    # agent 1: equip the ammo
+    ent_id = 1; item_sig = self.item_sig[ent_id][0]
+    inv_idx = env.obs[ent_id].inventory.sig(*item_sig)
+    self.assertEqual(1,
+      ItemState.parse_array(env.obs[ent_id].inventory.values[inv_idx]).equipped)
+
+    # agent 2: list the ammo for sale
+    ent_id = 2; price = 5; item_sig = self.item_sig[ent_id][0]
+    inv_idx = env.obs[ent_id].inventory.sig(*item_sig)
+    self.assertEqual(price,
+      ItemState.parse_array(env.obs[ent_id].inventory.values[inv_idx]).listed_price)
+    self.assertTrue(env.obs[ent_id].inventory.id(inv_idx) in env.obs[ent_id].market.ids)
+
+    """ Second tick actions """
+    actions = {}
+    test_cond = {}
+
+    # agent 1: give equipped ammo to agent 3 (invalid: should be masked)
+    test_cond[1] = { 'tgt_id': 3, 'item_sig': self.item_sig[1][0],
+                     'ent_mask': True, 'inv_mask': False, 'valid': False }
+    # agent 2: give listed ammo to agent 4 (invalid: should be masked)
+    test_cond[2] = { 'tgt_id': 4, 'item_sig': self.item_sig[2][0],
+                     'ent_mask': True, 'inv_mask': False, 'valid': False }
+
+    actions = self._check_assert_make_action(env, action.Give, test_cond)
+    env.step(actions)
+
+    # Check the second tick actions
+    # check the results
+    for ent_id, cond in test_cond.items():
+      self.assertEqual( cond['valid'],
+        env.obs[ent_id].inventory.sig(*cond['item_sig']) is None)
+
+    # DONE
+
+  def test_give_full_inventory(self):
+    # cannot give to an agent with the full inventory, 
+    #   but it's possible if the agent has the same ammo stack
+    env = self._setup_env(random_seed=RANDOM_SEED)
+
+    # make the inventory full for agents 1, 2
+    extra_items = { (Item.Bottom, 0), (Item.Bottom, 3) }
+    for ent_id in [1, 2]:
+      for item_sig in extra_items:
+        self.item_sig[ent_id].append(item_sig)
+        self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
+
+    env.obs = env._compute_observations()
+
+    # check if the inventory is full
+    for ent_id in [1, 2]:
+      self.assertEqual(env.obs[ent_id].inventory.len, env.config.ITEM_INVENTORY_CAPACITY)
+      self.assertTrue(env.realm.players[ent_id].inventory.space == 0)
+
+    """ First tick actions """
+    actions = {}
+    test_cond = {}
+
+    # agent 3: give ammo to agent 1 (the same ammo stack, so valid)
+    test_cond[3] = { 'tgt_id': 1, 'item_sig': self.item_sig[3][0],
+                     'ent_mask': True, 'inv_mask': True, 'valid': True }
+    # agent 4: give gloves to agent 2 (not the stack, so invalid)
+    test_cond[4] = { 'tgt_id': 2, 'item_sig': self.item_sig[4][4],
+                     'ent_mask': True, 'inv_mask': True, 'valid': False }
+
+    actions = self._check_assert_make_action(env, action.Give, test_cond)
+    env.step(actions)
+
+    # Check the first tick actions
+    # check the results
+    for ent_id, cond in test_cond.items():
+      self.assertEqual( cond['valid'],
+        env.obs[ent_id].inventory.sig(*cond['item_sig']) is None)
+      
+      if ent_id == 3: # successfully gave the ammo stack to agent 1
+        tgt_inv = env.obs[cond['tgt_id']].inventory
+        inv_idx = tgt_inv.sig(*cond['item_sig'])
+        self.assertEqual(2 * self.ammo_quantity,
+          ItemState.parse_array(tgt_inv.values[inv_idx]).quantity)
+
+    # DONE
+
+  def test_give_gold(self):
+    # cannot give to an npc (should be masked)
+    # cannot give to the other team member (should be masked)
+    # cannot give to self (should be masked)
+    # cannot give if not on the same tile (should be masked)
+    env = self._setup_env(random_seed=RANDOM_SEED)
+
+    # teleport the npc -1 to agent 3's location
+    self._change_spawn_pos(env.realm, -1, self.spawn_locs[3])
+    env.obs = env._compute_observations()
+
+    test_cond = {}
+
+    # NOTE: the below tests rely on the static execution order from 1 to N
+    # agent 1: give gold to agent 3 (valid: the same team, same tile)
+    test_cond[1] = { 'tgt_id': 3, 'gold': 1, 'ent_mask': True, 
+                     'ent_gold': self.init_gold-1, 'tgt_gold': self.init_gold+1 }
+    # agent 2: give gold to agent 4 (valid: the same team, same tile)
+    test_cond[2] = { 'tgt_id': 4, 'gold': 100, 'ent_mask': True,
+                     'ent_gold': 0, 'tgt_gold': 2*self.init_gold }
+    # agent 3: give gold to npc -1 (invalid: cannot give to npc)
+    #  ent_gold is self.init_gold+1 because (3) got 1 gold from (1)
+    test_cond[3] = { 'tgt_id': -1, 'gold': 1, 'ent_mask': False,
+                     'ent_gold': self.init_gold+1, 'tgt_gold': self.init_gold }
+    # agent 4: give -1 gold to 2 (invalid: cannot give minus gold)
+    #  ent_gold is 2*self.init_gold because (4) got 5 gold from (2)
+    #  tgt_gold is 0 because (2) gave all gold to (4)
+    test_cond[4] = { 'tgt_id': 2, 'gold': -1, 'ent_mask': True,
+                     'ent_gold': 2*self.init_gold, 'tgt_gold': 0 }
+    # agent 5: give gold to agent 2 (invalid: the same tile but other team)
+    #  tgt_gold is 0 because (2) gave all gold to (4)
+    test_cond[5] = { 'tgt_id': 2, 'gold': 1, 'ent_mask': False,
+                     'ent_gold': self.init_gold, 'tgt_gold': 0 }
+    # agent 6: give gold to agent 4 (invalid: the same team but other tile)
+    #  tgt_gold is 2*self.init_gold because (4) got 5 gold from (2)
+    test_cond[6] = { 'tgt_id': 4, 'gold': 1, 'ent_mask': False,
+                     'ent_gold': self.init_gold, 'tgt_gold': 2*self.init_gold }
+
+    actions = self._check_assert_make_action(env, action.GiveGold, test_cond)
+    env.step(actions)
+
+    # check the results
+    for ent_id, cond in test_cond.items():
+      self.assertEqual(cond['ent_gold'], env.realm.players[ent_id].gold.val)
+      if cond['tgt_id'] > 0:
+        self.assertEqual(cond['tgt_gold'], env.realm.players[cond['tgt_id']].gold.val)
+
+    # DONE
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/action/test_sell_buy.py
+++ b/tests/action/test_sell_buy.py
@@ -1,0 +1,180 @@
+import unittest
+import logging
+
+# pylint: disable=import-error
+from testhelpers import ScriptedTestTemplate
+
+from nmmo.io import action
+from nmmo.systems import item as Item
+from nmmo.systems.item import ItemState
+from scripted import baselines
+
+RANDOM_SEED = 985
+
+LOGFILE = 'tests/action/test_sell_buy.log'
+
+class TestSellBuy(ScriptedTestTemplate):
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+
+    # config specific to the tests here
+    cls.config.PLAYERS = [baselines.Melee, baselines.Range]
+    cls.config.PLAYER_N = 6
+
+    cls.policy = { 1:'Melee', 2:'Range', 3:'Melee', 4:'Range', 5:'Melee', 6:'Range' }
+    cls.ammo = { 1:Item.Scrap, 2:Item.Shaving, 3:Item.Scrap, 
+                 4:Item.Shaving, 5:Item.Scrap, 6:Item.Shaving }
+
+    cls.config.LOG_VERBOSE = False
+    if cls.config.LOG_VERBOSE:
+      logging.basicConfig(filename=LOGFILE, level=logging.INFO)
+
+
+  def test_sell_buy(self):
+    # cannot list an item with 0 price
+    # cannot list an equipped item for sale (should be masked)
+    # cannot buy an item with the full inventory,
+    #   but it's possible if the agent has the same ammo stack
+    # cannot buy its own item (should be masked)
+    # cannot buy an item if gold is not enough (should be masked)
+    # cannot list an already listed item for sale (should be masked)
+    env = self._setup_env(random_seed=RANDOM_SEED)
+
+    # make the inventory full for agents 1, 2
+    extra_items = { (Item.Bottom, 0), (Item.Bottom, 3) }
+    for ent_id in [1, 2]:
+      for item_sig in extra_items:
+        self.item_sig[ent_id].append(item_sig)
+        self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
+
+    env.obs = env._compute_observations()
+
+    # check if the inventory is full
+    for ent_id in [1, 2]:
+      self.assertEqual(env.obs[ent_id].inventory.len, env.config.ITEM_INVENTORY_CAPACITY)
+      self.assertTrue(env.realm.players[ent_id].inventory.space == 0)
+
+    """ First tick actions """
+    # cannot list an item with 0 price
+    actions = {}
+
+    # agent 1-2: equip the ammo
+    for ent_id in [1, 2]:
+      item_sig = self.item_sig[ent_id][0]
+      self.assertTrue(
+        self._check_inv_mask(env.obs[ent_id], action.Use, item_sig)) 
+      actions[ent_id] = { action.Use: { action.InventoryItem: 
+          env.obs[ent_id].inventory.sig(*item_sig) } }
+
+    # agent 4: list the ammo for sale with price 0 (invalid)
+    ent_id = 4; price = 0; item_sig = self.item_sig[ent_id][0]
+    actions[ent_id] = { action.Sell: { 
+        action.InventoryItem: env.obs[ent_id].inventory.sig(*item_sig),
+        action.Price: price } }
+
+    env.step(actions)
+
+    # Check the first tick actions
+    # agent 1-2: the ammo equipped, thus should be masked for sale
+    for ent_id in [1, 2]:
+      item_sig = self.item_sig[ent_id][0]
+      inv_idx = env.obs[ent_id].inventory.sig(*item_sig)
+      self.assertEqual(1, # equipped = true
+        ItemState.parse_array(env.obs[ent_id].inventory.values[inv_idx]).equipped)
+      self.assertFalse( # not allowed to list
+        self._check_inv_mask(env.obs[ent_id], action.Sell, item_sig)) 
+      
+      # and nothing is listed because agent 4's SELL is invalid
+      self.assertTrue(len(env.obs[ent_id].market.ids) == 0)
+
+    """ Second tick actions """
+    # listing the level-0 ammo with different prices
+    # cannot list an equipped item for sale (should be masked)
+
+    listing_price = { 1:1, 2:5, 3:15, 4:3, 5:1 } # gold
+    for ent_id in listing_price:
+      item_sig = self.item_sig[ent_id][0]
+      actions[ent_id] = { action.Sell: { 
+          action.InventoryItem: env.obs[ent_id].inventory.sig(*item_sig),
+          action.Price: listing_price[ent_id] } }
+
+    env.step(actions)
+
+    # Check the second tick actions
+    # agent 1-2: the ammo equipped, thus not listed for sale
+    # agent 3-5's ammos listed for sale
+    for ent_id in listing_price:
+      item_id = env.obs[ent_id].inventory.id(0)
+
+      if ent_id in [1, 2]: # failed to list for sale
+        self.assertFalse(item_id in env.obs[ent_id].market.ids) # not listed
+        self.assertEqual(0, 
+          ItemState.parse_array(env.obs[ent_id].inventory.values[0]).listed_price)
+      
+      else: # should succeed to list for sale
+        self.assertTrue(item_id in env.obs[ent_id].market.ids) # listed
+        self.assertEqual(listing_price[ent_id], # sale price set
+          ItemState.parse_array(env.obs[ent_id].inventory.values[0]).listed_price)
+        
+        # should not buy mine
+        self.assertFalse( self._check_mkt_mask(env.obs[ent_id], item_id)) 
+        
+        # should not list the same item twice
+        self.assertFalse(
+          self._check_inv_mask(env.obs[ent_id], action.Sell, self.item_sig[ent_id][0])) 
+
+    """ Third tick actions """
+    # cannot buy an item with the full inventory,
+    #   but it's possible if the agent has the same ammo stack
+    # cannot buy its own item (should be masked)
+    # cannot buy an item if gold is not enough (should be masked)
+    # cannot list an already listed item for sale (should be masked)
+
+    test_cond = {}
+
+    # agent 1: buy agent 5's ammo (valid: 1 has the same ammo stack)
+    #   although 1's inventory is full, this action is valid
+    agent5_ammo = env.obs[5].inventory.id(0)
+    test_cond[1] = { 'item_id': agent5_ammo, 'mkt_mask': True }
+
+    # agent 2: buy agent 5's ammo (invalid: full space and no same stack)
+    test_cond[2] = { 'item_id': agent5_ammo, 'mkt_mask': False }
+
+    # agent 4: cannot buy its own item (invalid)
+    test_cond[4] = { 'item_id': env.obs[4].inventory.id(0), 'mkt_mask': False }
+
+    # agent 5: cannot buy agent 3's ammo (invalid: not enought gold)
+    test_cond[5] = { 'item_id': env.obs[3].inventory.id(0), 'mkt_mask': False }
+
+    actions = self._check_assert_make_action(env, action.Buy, test_cond)
+
+    # agent 3: list an already listed item for sale (try different price)
+    ent_id = 3; item_sig = self.item_sig[ent_id][0]
+    actions[ent_id] = { action.Sell: { 
+        action.InventoryItem: env.obs[ent_id].inventory.sig(*item_sig),
+        action.Price: 7 } } # try to set different price
+
+    env.step(actions)
+
+    # Check the third tick actions
+    # agent 1: buy agent 5's ammo (valid: 1 has the same ammo stack)
+    #   agent 5's ammo should be gone
+    ent_id = 5; self.assertFalse( agent5_ammo in env.obs[ent_id].inventory.ids)
+    self.assertEqual( env.realm.players[ent_id].gold.val, # gold transfer
+                      self.init_gold + listing_price[ent_id])
+    
+    ent_id = 1; self.assertEqual(2 * self.ammo_quantity, # ammo transfer
+          ItemState.parse_array(env.obs[ent_id].inventory.values[0]).quantity)
+    self.assertEqual( env.realm.players[ent_id].gold.val, # gold transfer 
+                      self.init_gold - listing_price[ent_id])
+
+    # agent 2-4: invalid buy, no exchange, thus the same money
+    for ent_id in [2, 3, 4]:
+      self.assertEqual( env.realm.players[ent_id].gold.val, self.init_gold)
+    
+    # DONE
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/lib/test_serialized.py
+++ b/tests/lib/test_serialized.py
@@ -3,7 +3,7 @@ import unittest
 
 from nmmo.lib.serialized import SerializedState
 
-# pylint: disable=no-member,unused-argument
+# pylint: disable=no-member,unused-argument,unsubscriptable-object
 
 FooState = SerializedState.subclass("FooState", [
   "a", "b", "col"
@@ -36,13 +36,21 @@ class TestSerialized(unittest.TestCase):
   def test_serialized(self):
     state = FooState(MockDatastore(), FooState.Limits)
 
+    # initial value = 0
     self.assertEqual(state.a.val, 0)
+
+    # if given value is within the range, set to the value
     state.a.update(1)
     self.assertEqual(state.a.val, 1)
-    state.a.update(-20)
-    self.assertEqual(state.a.val, -10)
-    state.a.update(100)
-    self.assertEqual(state.a.val, 10)
+
+    # if given a lower value than the min, set to min
+    a_min, a_max = FooState.Limits["a"]
+    state.a.update(a_min - 100)
+    self.assertEqual(state.a.val, a_min)
+
+    # if given a higher value than the max, set to max
+    state.a.update(a_max + 100)
+    self.assertEqual(state.a.val, a_max)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/testhelpers.py
+++ b/tests/testhelpers.py
@@ -1,13 +1,15 @@
 import logging
+import unittest
+
 from copy import deepcopy
 import numpy as np
 
 import nmmo
 
 from scripted import baselines
-from nmmo.io.action import Move, Attack, Sell, Use, Give, Buy
 from nmmo.entity.entity import EntityState
-from nmmo.systems.item import ItemState
+from nmmo.io import action
+from nmmo.systems import item as Item
 
 # this function can be replaced by assertDictEqual
 # but might be still useful for debugging
@@ -81,7 +83,7 @@ def player_total(env):
 
 def count_actions(tick, actions):
   cnt_action = {}
-  for atn in (Move, Attack, Sell, Use, Give, Buy):
+  for atn in (action.Move, action.Attack, action.Sell, action.Use, action.Give, action.Buy):
     cnt_action[atn] = 0
 
   for ent_id in actions:
@@ -92,9 +94,9 @@ def count_actions(tick, actions):
         cnt_action[atn] = 1
 
   info_str = f"Tick: {tick}, acting agents: {len(actions)}, action counts " + \
-             f"move: {cnt_action[Move]}, attack: {cnt_action[Attack]}, " + \
-             f"sell: {cnt_action[Sell]}, use: {cnt_action[Move]}, " + \
-             f"give: {cnt_action[Give]}, buy: {cnt_action[Buy]}"
+             f"move: {cnt_action[action.Move]}, attack: {cnt_action[action.Attack]}, " + \
+             f"sell: {cnt_action[action.Sell]}, use: {cnt_action[action.Move]}, " + \
+             f"give: {cnt_action[action.Give]}, buy: {cnt_action[action.Buy]}"
   logging.info(info_str)
 
   return cnt_action
@@ -139,7 +141,7 @@ class ScriptedAgentTestEnv(nmmo.Env):
     self.actions = {}
     # manually resetting the EntityState, ItemState datastore tables
     EntityState.State.table(self.realm.datastore).reset()
-    ItemState.State.table(self.realm.datastore).reset()
+    Item.ItemState.State.table(self.realm.datastore).reset()
     return super().reset(map_id=map_id, seed=seed, options=options)
 
   def _compute_scripted_agent_actions(self, actions):
@@ -169,4 +171,190 @@ class ScriptedAgentTestEnv(nmmo.Env):
     #   to be reconciled.
 
     # bypass the current _process_actions()
+    return actions
+
+
+# pylint: disable=invalid-name,protected-access
+class ScriptedTestTemplate(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    # only use Combat agents
+    cls.config = ScriptedAgentTestConfig()
+    cls.config.PLAYERS = [baselines.Melee, baselines.Range, baselines.Mage]
+    cls.config.PLAYER_N = 3
+    #cls.config.IMMORTAL = True
+
+    # set up agents to test ammo use
+    cls.policy = { 1:'Melee', 2:'Range', 3:'Mage' }
+    # 1 cannot hit 3, 2 can hit 1, 3 cannot hit 2
+    cls.spawn_locs = { 1:(17, 17), 2:(17, 19), 3:(21, 21) }
+    cls.ammo = { 1:Item.Scrap, 2:Item.Shaving, 3:Item.Shard }
+    cls.ammo_quantity = 2
+
+    # items to provide
+    cls.init_gold = 5
+    cls.item_level = [0, 3] # 0 can be used, 3 cannot be used
+    cls.item_sig = {}
+
+  def _change_spawn_pos(self, realm, ent_id, new_pos):
+    # check if the position is valid
+    assert realm.map.tiles[new_pos].habitable, "Given pos is not habitable."
+    assert realm.entity(ent_id), "No such entity in the realm"
+
+    entity = realm.entity(ent_id)
+    old_pos = entity.pos
+    realm.map.tiles[old_pos].remove_entity(ent_id)
+
+    # set to new pos
+    entity.row.update(new_pos[0])
+    entity.col.update(new_pos[1])
+    entity.spawn_pos = new_pos
+    realm.map.tiles[new_pos].add_entity(entity)
+
+  def _provide_item(self, realm, ent_id, item, level, quantity):
+    realm.players[ent_id].inventory.receive(
+      item(realm, level=level, quantity=quantity))
+
+  def _make_item_sig(self):
+    item_sig = {}
+    for ent_id, ammo in self.ammo.items():
+      item_sig[ent_id] = []
+      for item in [ammo, Item.Top, Item.Gloves, Item.Ration, Item.Poultice]:
+        for lvl in self.item_level:
+          item_sig[ent_id].append((item, lvl))
+
+    return item_sig
+
+  def _setup_env(self, random_seed, check_assert=True):
+    """ set up a new env and perform initial checks """
+    env = ScriptedAgentTestEnv(self.config, seed=random_seed)
+    env.reset()
+
+    # provide money for all
+    for ent_id in env.realm.players:
+      env.realm.players[ent_id].gold.update(self.init_gold)
+
+    # provide items that are in item_sig
+    self.item_sig = self._make_item_sig()
+    for ent_id, items in self.item_sig.items():
+      for item_sig in items:
+        if item_sig[0] == self.ammo[ent_id]:
+          self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], self.ammo_quantity)
+        else:
+          self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
+
+    # teleport the players, if provided with specific locations
+    for ent_id, pos in self.spawn_locs.items():
+      self._change_spawn_pos(env.realm, ent_id, pos)
+
+    env.obs = env._compute_observations()
+
+    if check_assert:
+      self._check_default_asserts(env)
+
+    return env
+
+  def _check_ent_mask(self, ent_obs, atn, target_id):
+    assert atn in [action.Give, action.GiveGold], "Invalid action"
+    gym_obs = ent_obs.to_gym()
+    mask = gym_obs['ActionTargets'][atn][action.Target][:ent_obs.entities.len] > 0
+
+    return target_id in ent_obs.entities.ids[mask]
+
+  def _check_inv_mask(self, ent_obs, atn, item_sig):
+    assert atn in [action.Destroy, action.Give, action.Sell, action.Use], "Invalid action"
+    gym_obs = ent_obs.to_gym()
+    mask = gym_obs['ActionTargets'][atn][action.InventoryItem][:ent_obs.inventory.len] > 0
+    inv_idx = ent_obs.inventory.sig(*item_sig)
+
+    return ent_obs.inventory.id(inv_idx) in ent_obs.inventory.ids[mask]
+
+  def _check_mkt_mask(self, ent_obs, item_id):
+    gym_obs = ent_obs.to_gym()
+    mask = gym_obs['ActionTargets'][action.Buy][action.MarketItem][:ent_obs.market.len] > 0
+
+    return item_id in ent_obs.market.ids[mask]
+
+  def _check_default_asserts(self, env):
+    """ The below asserts are based on the hardcoded values in setUpClass()
+        This should not run when different values were used
+    """
+    # check if the agents are in specified positions
+    for ent_id, pos in self.spawn_locs.items():
+      self.assertEqual(env.realm.players[ent_id].pos, pos)
+
+    for ent_id, sig_list in self.item_sig.items():
+      # ammo instances are in the datastore and global item registry (realm)
+      inventory = env.obs[ent_id].inventory
+      self.assertTrue(inventory.len == len(sig_list))
+      for inv_idx in range(inventory.len):
+        item_id = inventory.id(inv_idx)
+        self.assertTrue(Item.ItemState.Query.by_id(env.realm.datastore, item_id) is not None)
+        self.assertTrue(item_id in env.realm.items)
+
+      for lvl in self.item_level:
+        inv_idx = inventory.sig(self.ammo[ent_id], lvl)
+        self.assertTrue(inv_idx is not None)
+        self.assertEqual(self.ammo_quantity, # provided 2 ammos
+          Item.ItemState.parse_array(inventory.values[inv_idx]).quantity)
+
+      # check ActionTargets
+      ent_obs = env.obs[ent_id]
+
+      if env.config.ITEM_SYSTEM_ENABLED:
+        # USE InventoryItem mask
+        for item_sig in sig_list:
+          if item_sig[1] == 0:
+            # items that can be used
+            self.assertTrue(self._check_inv_mask(ent_obs, action.Use, item_sig))
+          else:
+            # items that are too high to use
+            self.assertFalse(self._check_inv_mask(ent_obs, action.Use, item_sig))
+
+      if env.config.EXCHANGE_SYSTEM_ENABLED:
+        # SELL InventoryItem mask
+        for item_sig in sig_list:
+          # the agent can sell anything now
+          self.assertTrue(self._check_inv_mask(ent_obs, action.Sell, item_sig))
+
+        # BUY MarketItem mask -- there is nothing on the market, so mask should be all 0
+        self.assertTrue(len(env.obs[ent_id].market.ids) == 0)
+
+  def _check_assert_make_action(self, env, atn, test_cond):
+    assert atn in [action.Give, action.GiveGold, action.Buy], "Invalid action"
+    actions = {}
+    for ent_id, cond in test_cond.items():
+      ent_obs = env.obs[ent_id]
+
+      if atn in [action.Give, action.GiveGold]:
+        # self should be always masked
+        self.assertFalse(self._check_ent_mask(ent_obs, atn, ent_id))
+
+        # check if the target is masked as expected
+        self.assertEqual( cond['ent_mask'],
+          self._check_ent_mask(ent_obs, atn, cond['tgt_id']) )
+
+      if atn in [action.Give]:
+        self.assertEqual( cond['inv_mask'],
+          self._check_inv_mask(ent_obs, atn, cond['item_sig']) )
+
+      if atn in [action.Buy]:
+        self.assertEqual( cond['mkt_mask'],
+          self._check_mkt_mask(ent_obs, cond['item_id']) )
+
+      # append the actions
+      if atn == action.Give:
+        actions[ent_id] = { action.Give: {
+          action.InventoryItem: env.obs[ent_id].inventory.sig(*cond['item_sig']),
+          action.Target: cond['tgt_id'] } }
+
+      elif atn == action.GiveGold:
+        actions[ent_id] = { action.GiveGold:
+          { action.Target: cond['tgt_id'], action.Price: cond['gold'] } }
+
+      elif atn == action.Buy:
+        mkt_idx = ent_obs.market.index(cond['item_id'])
+        actions[ent_id] = { action.Buy: { action.MarketItem: mkt_idx } }
+
     return actions

--- a/tests/testhelpers.py
+++ b/tests/testhelpers.py
@@ -60,6 +60,11 @@ def observations_are_equal(source_obs, target_obs, debug=True):
 
     obj = ent_src.keys()
     for o in obj:
+
+      # ActionTargets causes a problem here, so skip it
+      if o == "ActionTargets":
+        continue
+
       obj_src = ent_src[o]
       obj_tgt = ent_tgt[o]
       if np.sum(obj_src != obj_tgt) > 0:


### PR DESCRIPTION
* renamed/adjusted obs N in the config: INVENTORY_N_OBS (<- ITEM_N_OBS), MARKET_N_OBS (<- EXCHANGE_N_OBS), COMMUNICATION_NUM_TOKENS
* separated InventoryItem (for sell/use/give) and MarketItem (for buy) classes and fixed other places accordingly, like io/action.py and scripted/baselines.py
* implemented ActionTargets in `nmmo/core/observation.py`, which provide binary masks to indicate valid action parameters
* reviewed and changed the skill levels required for using items, mainly using the max over all skills for using armors, ration, poultice (still, specific skill levels required for other tools, weapons, ammo )
* extended `test_ammo_use.py` to include ActionTargets and Observations tests
* made the last ammo count (before the fix, the last ammo was used without adding ammo damage)

and some minor edits here and there

----

* Added DESTROY (item), GIVE-GOLD actions
* Added ActionTargets and unit tests for USE, GIVE, DESTROY, BUY, SELL, GIVE-GOLD and fixed a bunch to make these work as expected
* Cleaned up io/action.py, and placed asserts in a consistent manner, and linted it 
* Can add the existing ammo stack during GIVE/BUY when the inventory is full
* Changed realm.step(): adjusted action priorities, only alive agents execute actions, shuffled only BUY order

```
    #  3 -> 10: Use - equip ammo, restore HP, etc.
    #  4 -> 20: Buy - exchange while sellers, items, buyers are all intact
    #  2 -> 30: Give, GiveGold - transfer while both are alive and at the same tile
    #  New  40: Destroy - use with SELL/GIVE, if not gone, destroy and recover space
    #  0 -> 50: Attack
    #  1 -> 60: Move
    #  4 -> 70: Sell - to guarantee the listed items are available to buy
    #  0 -> 99: Comm
```
