### PR TITLE
Added event logging

### DIFF
--- a/nmmo/core/realm.py
+++ b/nmmo/core/realm.py
@@ -18,6 +18,7 @@ from nmmo.io.action import Action, Buy
 from nmmo.datastore.numpy_datastore import NumpyDatastore
 from nmmo.systems.exchange import Exchange
 from nmmo.systems.item import Item, ItemState
+from nmmo.lib.event_log import EventLogger, EventState
 
 def prioritized(entities: Dict, merged: Dict):
   """Sort actions into merged according to priority"""
@@ -42,7 +43,7 @@ class Realm:
     config.MAP_GENERATOR(config).generate_all_maps()
 
     self.datastore = NumpyDatastore()
-    for s in [TileState, EntityState, ItemState]:
+    for s in [TileState, EntityState, ItemState, EventState]:
       self.datastore.register_object_type(s._name, s.State.num_attributes)
 
     self.tick = 0
@@ -54,6 +55,7 @@ class Realm:
     self.replay_helper = ReplayHelper.create(self)
     self.render_helper = RenderHelper.create(self)
     self.log_helper = LogHelper.create(self)
+    self.event_log = EventLogger(self)
 
     # Entity handlers
     self.players = PlayerManager(self)
@@ -72,6 +74,7 @@ class Realm:
         idx: Map index to load
     """
     self.log_helper.reset()
+    self.event_log.reset()
     self.map.reset(map_id or np.random.randint(self.config.MAP_N) + 1)
 
     # EntityState and ItemState tables must be empty after players/npcs.reset()

--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -8,6 +8,7 @@ from nmmo.core.config import Config
 from nmmo.lib import utils
 from nmmo.datastore.serialized import SerializedState
 from nmmo.systems import inventory
+from nmmo.lib.log import EventCode
 
 # pylint: disable=no-member
 EntityState = SerializedState.subclass(
@@ -290,6 +291,7 @@ class Entity(EntityState):
     # at this point, self is dead
     if source:
       source.history.player_kills += 1
+      self.realm.event_log.record(EventCode.SCORE_KILL, source, target=self)
 
     # if self is dead, unlist its items from the market regardless of looting
     if self.config.EXCHANGE_SYSTEM_ENABLED:

--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -291,7 +291,7 @@ class Entity(EntityState):
     # at this point, self is dead
     if source:
       source.history.player_kills += 1
-      self.realm.event_log.record(EventCode.SCORE_KILL, source, target=self)
+      self.realm.event_log.record(EventCode.PLAYER_KILL, source, target=self)
 
     # if self is dead, unlist its items from the market regardless of looting
     if self.config.EXCHANGE_SYSTEM_ENABLED:

--- a/nmmo/io/action.py
+++ b/nmmo/io/action.py
@@ -7,6 +7,7 @@ from ordered_set import OrderedSet
 from nmmo.lib import utils
 from nmmo.lib.utils import staticproperty
 from nmmo.systems.item import Item, Stack
+from nmmo.lib.log import EventCode
 
 class NodeType(Enum):
   #Tree edges
@@ -418,6 +419,8 @@ class Destroy(Node):
     entity.inventory.remove(item)
     item.destroy()
 
+    realm.event_log.record(EventCode.DESTROY_ITEM, entity)
+
 class Give(Node):
   priority = 30
 
@@ -468,6 +471,8 @@ class Give(Node):
     entity.inventory.remove(item)
     target.inventory.receive(item)
 
+    realm.event_log.record(EventCode.GIVE_ITEM, entity)
+
 
 class GiveGold(Node):
   priority = 30
@@ -510,6 +515,8 @@ class GiveGold(Node):
 
     entity.gold.decrement(amount)
     target.gold.increment(amount)
+
+    realm.event_log.record(EventCode.GIVE_GOLD, entity)
 
 
 class MarketItem(Node):

--- a/nmmo/lib/event_log.py
+++ b/nmmo/lib/event_log.py
@@ -91,7 +91,7 @@ class EventLogger(EventCode):
         log.number.update(kwargs['damage'])
         return
 
-    if event_code == EventCode.SCORE_KILL:
+    if event_code == EventCode.PLAYER_KILL:
       if ('target' in kwargs and isinstance(kwargs['target'], Entity)):
         target = kwargs['target']
         log = self._create_event(entity, event_code)

--- a/nmmo/lib/event_log.py
+++ b/nmmo/lib/event_log.py
@@ -1,0 +1,167 @@
+from types import SimpleNamespace
+from typing import List
+from copy import deepcopy
+
+import numpy as np
+
+from nmmo.datastore.serialized import SerializedState
+from nmmo.core.realm import Realm
+from nmmo.entity import Entity
+from nmmo.systems.item import Item
+from nmmo.systems import skill as Skill
+
+# pylint: disable=no-member
+EventState = SerializedState.subclass("Event", [
+  "id", # unique event id
+  "ent_id",
+  "tick",
+
+  "event",
+
+  "type",
+  "level",
+  "number",
+  "gold",
+  "target_ent",
+])
+
+EventAttr = EventState.State.attr_name_to_col
+
+EventState.Query = SimpleNamespace(
+  table=lambda ds: ds.table("Event").where_neq(EventAttr["id"], 0),
+
+  by_event=lambda ds, event_code: ds.table("Event").where_eq(
+    EventAttr["event"], event_code),
+)
+
+# matching the names to base predicates
+class EventCode:
+  # Move
+  EAT_FOOD = 1
+  DRINK_WATER = 2
+
+  # Attack
+  SCORE_HIT = 11
+  SCORE_KILL = 12
+  style_to_int = { Skill.Melee: 1, Skill.Range:2, Skill.Mage:3 }
+  attack_col_map = {
+    'combat_style': EventAttr['type'],
+    'damage': EventAttr['number'] }
+
+  # Item
+  CONSUME_ITEM = 21
+  GIVE_ITEM = 22
+  DESTROY_ITEM = 23
+  PRODUCE_ITEM = 24
+  item_col_map = {
+    'item_type': EventAttr['type'],
+    'quantity': EventAttr['number'],
+    'price': EventAttr['gold'] }
+
+  # Exchange
+  GIVE_GOLD = 31
+  LIST_ITEM = 32
+  EARN_GOLD = 33
+  BUY_ITEM = 34
+  SPEND_GOLD = 35
+
+
+class EventLogger(EventCode):
+  def __init__(self, realm: Realm):
+    self.realm = realm
+    self.config = realm.config
+    self.datastore = realm.datastore
+
+    self.valid_events = { val: evt for evt, val in EventCode.__dict__.items()
+                           if isinstance(val, int) }
+
+    # create a custom attr-col mapping
+    self.attr_to_col = deepcopy(EventAttr)
+    self.attr_to_col.update(EventCode.attack_col_map)
+    self.attr_to_col.update(EventCode.item_col_map)
+
+  def reset(self):
+    EventState.State.table(self.datastore).reset()
+
+  # define event logging
+  def _create_event(self, entity: Entity, event_code: int):
+    log = EventState(self.datastore)
+    log.id.update(log.datastore_record.id)
+    log.ent_id.update(entity.ent_id)
+    log.tick.update(self.realm.tick)
+    log.event.update(event_code)
+
+    return log
+
+  def record(self, event_code: int, entity: Entity, **kwargs):
+    if event_code in [EventCode.EAT_FOOD, EventCode.DRINK_WATER,
+                      EventCode.GIVE_ITEM, EventCode.DESTROY_ITEM,
+                      EventCode.GIVE_GOLD]:
+      # Logs for these events are for counting only
+      self._create_event(entity, event_code)
+      return
+
+    if event_code == EventCode.SCORE_HIT:
+      if ('combat_style' in kwargs and kwargs['combat_style'] in EventCode.style_to_int) & \
+         ('damage' in kwargs and kwargs['damage'] >= 0):
+        log = self._create_event(entity, event_code)
+        log.type.update(EventCode.style_to_int[kwargs['combat_style']])
+        log.number.update(kwargs['damage'])
+        return
+
+    if event_code == EventCode.SCORE_KILL:
+      if ('target' in kwargs and isinstance(kwargs['target'], Entity)):
+        target = kwargs['target']
+        log = self._create_event(entity, event_code)
+        log.target_ent.update(target.ent_id)
+
+        # CHECK ME: attack_level or "general" level?? need to clarify
+        log.level.update(target.attack_level)
+        return
+
+    if event_code in [EventCode.CONSUME_ITEM, EventCode.PRODUCE_ITEM]:
+      # CHECK ME: item types should be checked. For example,
+      #   Only Ration and Poultice can be consumed
+      #   Only Ration, Poultice, Scrap, Shaving, Shard can be produced
+      if ('item' in kwargs and isinstance(kwargs['item'], Item)):
+        item = kwargs['item']
+        log = self._create_event(entity, event_code)
+        log.type.update(item.ITEM_TYPE_ID)
+        log.level.update(item.level.val)
+        log.number.update(item.quantity.val)
+        return
+
+    if event_code in [EventCode.LIST_ITEM, EventCode.BUY_ITEM]:
+      if ('item' in kwargs and isinstance(kwargs['item'], Item)) & \
+         ('price' in kwargs and kwargs['price'] > 0):
+        item = kwargs['item']
+        log = self._create_event(entity, event_code)
+        log.type.update(item.ITEM_TYPE_ID)
+        log.level.update(item.level.val)
+        log.number.update(item.quantity.val)
+        log.gold.update(kwargs['price'])
+        return
+
+    if event_code in [EventCode.EARN_GOLD, EventCode.SPEND_GOLD]:
+      if ('amount' in kwargs and kwargs['amount'] > 0):
+        log = self._create_event(entity, event_code)
+        log.gold.update(kwargs['amount'])
+        return
+
+    # If reached here, then something is wrong
+    # CHECK ME: The below should be commented out after debugging
+    raise ValueError(f"Event code: {event_code}", kwargs)
+
+  def get_data(self, event_code=None, agents: List[int]=None):
+    if event_code is None:
+      event_data = EventState.Query.table(self.datastore).astype(np.int16)
+    elif event_code in self.valid_events:
+      event_data = EventState.Query.by_event(self.datastore, event_code).astype(np.int16)
+    else:
+      return None
+
+    if agents:
+      flt_idx = np.in1d(event_data[:, EventAttr['ent_id']], agents)
+      return event_data[flt_idx]
+
+    return event_data

--- a/nmmo/lib/log.py
+++ b/nmmo/lib/log.py
@@ -45,7 +45,7 @@ class EventCode:
 
   # Attack
   SCORE_HIT = 11
-  SCORE_KILL = 12
+  PLAYER_KILL = 12
 
   # Item
   CONSUME_ITEM = 21

--- a/nmmo/lib/log.py
+++ b/nmmo/lib/log.py
@@ -33,3 +33,32 @@ class MilestoneLogger(Logger):
 
     self.log(key, val)
     return True
+
+
+# CHECK ME: Is this a good place to put here?
+#   EventCode is used in many places, and I(kywch)'m putting it here
+#   to avoid a circular import, which happened a few times with event_log.py
+class EventCode:
+  # Move
+  EAT_FOOD = 1
+  DRINK_WATER = 2
+
+  # Attack
+  SCORE_HIT = 11
+  SCORE_KILL = 12
+
+  # Item
+  CONSUME_ITEM = 21
+  GIVE_ITEM = 22
+  DESTROY_ITEM = 23
+  HARVEST_ITEM = 24
+
+  # Exchange
+  GIVE_GOLD = 31
+  LIST_ITEM = 32
+  EARN_GOLD = 33
+  BUY_ITEM = 34
+  #SPEND_GOLD = 35 # BUY_ITEM, price has the same info
+
+  # Level up
+  LEVEL_UP = 41

--- a/nmmo/systems/combat.py
+++ b/nmmo/systems/combat.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from nmmo.systems import skill as Skill
+from nmmo.lib.log import EventCode
 
 def level(skills):
   return max(e.level.val for e in skills.skills)
@@ -97,6 +98,9 @@ def attack(realm, player, target, skill_fn):
   if player.is_player:
     equipment_level_offense = player.equipment.total(lambda e: e.level)
     equipment_level_defense = target.equipment.total(lambda e: e.level)
+
+    realm.event_log.record(EventCode.SCORE_HIT, player,
+                           combat_style=skill_type, damage=damage)
 
     realm.log_milestone(f'Damage_{skill_name}', damage,
                         f'COMBAT: Inflicted {damage} {skill_name} damage ' +

--- a/nmmo/systems/exchange.py
+++ b/nmmo/systems/exchange.py
@@ -5,6 +5,7 @@ import math
 from typing import Dict
 
 from nmmo.systems.item import Item, Stack
+from nmmo.lib.log import EventCode
 
 """
 The Exchange class is a simulation of an in-game item exchange.
@@ -99,6 +100,8 @@ class Exchange:
 
     self._list_item(item, seller, price, tick)
 
+    self._realm.event_log.record(EventCode.LIST_ITEM, seller, item=item, price=price)
+
     self._realm.log_milestone(f'Sell_{item.__class__.__name__}', item.level.val,
       f'EXCHANGE: Offered level {item.level.val} {item.__class__.__name__} for {price} gold',
       tags={"player_id": seller.ent_id})
@@ -130,9 +133,11 @@ class Exchange:
     buyer.gold.decrement(price)
     listing.seller.gold.increment(price)
 
-    # TODO(kywch): fix logs
+    # TODO(kywch): tidy up the logs - milestone, event, etc ...
     #self._realm.log_milestone(f'Buy_{item.__name__}', item.level.val)
     #self._realm.log_milestone('Transaction_Amount', item.listed_price.val)
+    self._realm.event_log.record(EventCode.BUY_ITEM, buyer, item=item, price=price)
+    self._realm.event_log.record(EventCode.EARN_GOLD, listing.seller, amount=price)
 
   @property
   def packet(self):

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -108,7 +108,7 @@ class Item(ItemState):
     realm.items[self.id.val] = self
 
   def destroy(self):
-    del self.realm.items[self.id.val]
+    self.realm.items.pop(self.id.val, None)
     self.datastore_record.delete()
 
   @property

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -7,6 +7,7 @@ from typing import Dict
 
 from nmmo.lib.colors import Tier
 from nmmo.datastore.serialized import SerializedState
+from nmmo.lib.log import EventCode
 
 # pylint: disable=no-member
 ItemState = SerializedState.subclass("Item", [
@@ -381,6 +382,8 @@ class Consumable(Item):
       f"PROF: Consumed {self.level.val} {self.__class__.__name__} "
       f"by Entity level {entity.attack_level}",
       tags={"player_id": entity.ent_id})
+
+    self.realm.event_log.record(EventCode.CONSUME_ITEM, entity, item=self)
 
     self._apply_effects(entity)
     entity.inventory.remove(self)

--- a/scripted/baselines.py
+++ b/scripted/baselines.py
@@ -246,7 +246,7 @@ class Scripted(nmmo.Agent):
 
   def sell(self, keep_k: dict, keep_best: set):
     for itm in self.inventory.values():
-      price = int(max(itm.level, len(action.Price.edges)-1))
+      price = int(max(itm.level, 1))
       assert itm.quantity > 0
 
       if itm.equipped or itm.listed_price:
@@ -266,7 +266,7 @@ class Scripted(nmmo.Agent):
 
       self.actions[action.Sell] = {
         action.InventoryItem: self.ob.inventory.index(itm.id), # list(self.ob.inventory.ids).index(itm.id)
-        action.Price: action.Price.edges[price] }
+        action.Price: action.Price.edges[price-1] } # Price starts from 1
 
       return itm
 

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -46,7 +46,7 @@ class TestEventLog(unittest.TestCase):
     event_log.record(EventCode.DRINK_WATER, MockEntity(2))
     event_log.record(EventCode.SCORE_HIT, MockEntity(2),
                      combat_style=Skill.Melee, damage=50)
-    event_log.record(EventCode.SCORE_KILL, MockEntity(3),
+    event_log.record(EventCode.PLAYER_KILL, MockEntity(3),
                      target=MockEntity(5, attack_level=5))
 
     mock_realm.tick = 2
@@ -76,7 +76,7 @@ class TestEventLog(unittest.TestCase):
       [ 1,  1, 1, EventCode.EAT_FOOD, 0, 0, 0, 0, 0],
       [ 2,  2, 1, EventCode.DRINK_WATER, 0, 0, 0, 0, 0],
       [ 3,  2, 1, EventCode.SCORE_HIT, 1, 0, 50, 0, 0],
-      [ 4,  3, 1, EventCode.SCORE_KILL, 0, 5, 0, 0, 5],
+      [ 4,  3, 1, EventCode.PLAYER_KILL, 0, 5, 0, 0, 5],
       [ 5,  4, 2, EventCode.CONSUME_ITEM, 16, 8, 1, 0, 0],
       [ 6,  4, 2, EventCode.GIVE_ITEM, 0, 0, 0, 0, 0],
       [ 7,  5, 2, EventCode.DESTROY_ITEM, 0, 0, 0, 0, 0],

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -1,0 +1,74 @@
+import unittest
+
+from tests.testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
+
+from nmmo.lib.event_log import EventState, EventCode, EventLogger
+from nmmo.systems.item import Scrap, Ration
+from nmmo.systems import skill as Skill
+
+
+class TestEventLog(unittest.TestCase):
+
+  def test_event_logging(self):
+    config =  ScriptedAgentTestConfig()
+    env = ScriptedAgentTestEnv(config)
+    env.reset()
+
+    # EventCode.SCORE_KILL: set level for agent 5 (target)
+    env.realm.players[5].skills.range.level.update(5)
+
+    # initialize Event datastore
+    env.realm.datastore.register_object_type("Event", EventState.State.num_attributes)
+
+    event_log = EventLogger(env.realm)
+
+    """logging events to test/count"""
+
+    # tick = 1
+    env.step({})
+    event_log.record(EventCode.EAT_FOOD, env.realm.players[1])
+    event_log.record(EventCode.DRINK_WATER, env.realm.players[2])
+    event_log.record(EventCode.SCORE_HIT, env.realm.players[2],
+                     combat_style=Skill.Melee, damage=50)
+    event_log.record(EventCode.SCORE_KILL, env.realm.players[3],
+                     target=env.realm.players[5])
+
+    # tick = 2
+    env.step({})
+    event_log.record(EventCode.CONSUME_ITEM, env.realm.players[4],
+                     item=Ration(env.realm, 8))
+    event_log.record(EventCode.GIVE_ITEM, env.realm.players[4])
+    event_log.record(EventCode.DESTROY_ITEM, env.realm.players[5])
+    event_log.record(EventCode.PRODUCE_ITEM, env.realm.players[6],
+                     item=Scrap(env.realm, 3))
+
+    # tick = 3
+    env.step({})
+    event_log.record(EventCode.GIVE_GOLD, env.realm.players[7])
+    event_log.record(EventCode.LIST_ITEM, env.realm.players[8],
+                     item=Ration(env.realm, 5), price=11)
+    event_log.record(EventCode.EARN_GOLD, env.realm.players[9], amount=15)
+    event_log.record(EventCode.BUY_ITEM, env.realm.players[10],
+                     item=Scrap(env.realm, 7), price=21)
+    event_log.record(EventCode.SPEND_GOLD, env.realm.players[11], amount=25)
+
+    log_data = [list(row) for row in event_log.get_data()]
+
+    self.assertListEqual(log_data, [
+      [ 1,  1, 1, EventCode.EAT_FOOD, 0, 0, 0, 0, 0],
+      [ 2,  2, 1, EventCode.DRINK_WATER, 0, 0, 0, 0, 0],
+      [ 3,  2, 1, EventCode.SCORE_HIT, 1, 0, 50, 0, 0],
+      [ 4,  3, 1, EventCode.SCORE_KILL, 0, 5, 0, 0, 5],
+      [ 5,  4, 2, EventCode.CONSUME_ITEM, 16, 8, 1, 0, 0],
+      [ 6,  4, 2, EventCode.GIVE_ITEM, 0, 0, 0, 0, 0],
+      [ 7,  5, 2, EventCode.DESTROY_ITEM, 0, 0, 0, 0, 0],
+      [ 8,  6, 2, EventCode.PRODUCE_ITEM, 13, 3, 1, 0, 0],
+      [ 9,  7, 3, EventCode.GIVE_GOLD, 0, 0, 0, 0, 0],
+      [10,  8, 3, EventCode.LIST_ITEM, 16, 5, 1, 11, 0],
+      [11,  9, 3, EventCode.EARN_GOLD, 0, 0, 0, 15, 0],
+      [12, 10, 3, EventCode.BUY_ITEM, 13, 7, 1, 21, 0],
+      [13, 11, 3, EventCode.SPEND_GOLD, 0, 0, 0, 25, 0]])
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
* Created a numpy datastore-based Event table for logging events
* Added tracking codes for 13 event types:
  * EAT_FOOD
  * DRINK_WATER
  * SCORE_HIT
  * <s>SCORE_KILL</s> -> PLAYER_KILL
  * CONSUME_ITEM
  * GIVE_ITEM
  * DESTROY_ITEM
  * HARVEST_ITEM
  * GIVE_GOLD
  * LIST_ITEM
  * EARN_GOLD
  * BUY_ITEM
  * LEVEL_UP

Some event tracking codes are adjacent to the legacy milestone logging code. It'd be great if we could merge these together.