### PR TITLE
removed quantity arg from Item.__init__()

### DIFF
--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -78,9 +78,14 @@ class Observation:
         Vector corresponding to the specified tile
     '''
     agent = self.agent()
-    r_cond = (self.tiles[:,TileState.State.attr_name_to_col["row"]] == agent.row + r_delta)
-    c_cond = (self.tiles[:,TileState.State.attr_name_to_col["col"]] == agent.col + c_delta)
-    return TileState.parse_array(self.tiles[r_cond & c_cond][0])
+    if (0 <= agent.row + r_delta < self.config.MAP_SIZE) & \
+       (0 <= agent.col + c_delta < self.config.MAP_SIZE):
+      r_cond = (self.tiles[:,TileState.State.attr_name_to_col["row"]] == agent.row + r_delta)
+      c_cond = (self.tiles[:,TileState.State.attr_name_to_col["col"]] == agent.col + c_delta)
+      return TileState.parse_array(self.tiles[r_cond & c_cond][0])
+
+    # return a dummy lava tile at (inf, inf)
+    return TileState.parse_array([np.inf, np.inf, material.Lava.index])    
 
   # pylint: disable=method-cache-max-size-none
   @lru_cache(maxsize=None)

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -85,7 +85,7 @@ class Observation:
       return TileState.parse_array(self.tiles[r_cond & c_cond][0])
 
     # return a dummy lava tile at (inf, inf)
-    return TileState.parse_array([np.inf, np.inf, material.Lava.index])    
+    return TileState.parse_array([np.inf, np.inf, material.Lava.index])
 
   # pylint: disable=method-cache-max-size-none
   @lru_cache(maxsize=None)

--- a/nmmo/systems/droptable.py
+++ b/nmmo/systems/droptable.py
@@ -1,22 +1,20 @@
 import numpy as np
 
 class Fixed():
-  def __init__(self, item, amount=1):
+  def __init__(self, item):
     self.item = item
-    self.amount = amount
 
   def roll(self, realm, level):
-    return [self.item(realm, level, amount=self.amount)]
+    return [self.item(realm, level)]
 
 class Drop:
-  def __init__(self, item, amount, prob):
+  def __init__(self, item, prob):
     self.item = item
-    self.amount = amount
     self.prob = prob
 
   def roll(self, realm, level):
     if np.random.rand() < self.prob:
-      return self.item(realm, level, quantity=self.amount)
+      return self.item(realm, level)
 
     return None
 
@@ -24,8 +22,8 @@ class Standard:
   def __init__(self):
     self.drops = []
 
-  def add(self, item, quant=1, prob=1.0):
-    self.drops += [Drop(item, quant, prob)]
+  def add(self, item, prob=1.0):
+    self.drops += [Drop(item, prob)]
 
   def roll(self, realm, level):
     ret = []

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -81,7 +81,7 @@ class Item(ItemState):
     return Item._item_type_id_to_class[type_id]
 
   def __init__(self, realm, level,
-              capacity=0, quantity=1,
+              capacity=0,
               melee_attack=0, range_attack=0, mage_attack=0,
               melee_defense=0, range_defense=0, mage_defense=0,
               health_restore=0, resource_restore=0):
@@ -96,7 +96,8 @@ class Item(ItemState):
     self.type_id.update(self.ITEM_TYPE_ID)
     self.level.update(level)
     self.capacity.update(capacity)
-    self.quantity.update(quantity)
+    # every item instance is created individually, i.e., quantity=1
+    self.quantity.update(1)
     self.melee_attack.update(melee_attack)
     self.range_attack.update(range_attack)
     self.mage_attack.update(mage_attack)

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -2,7 +2,7 @@ import unittest
 import logging
 
 # pylint: disable=import-error
-from testhelpers import ScriptedTestTemplate
+from testhelpers import ScriptedTestTemplate, provide_item
 
 from nmmo.io import action
 from nmmo.systems import item as Item
@@ -96,14 +96,14 @@ class TestAmmoUse(ScriptedTestTemplate):
     # provide extra scrap to range to make its inventory full
     # but level-0 scrap overlaps with the listed item
     ent_id = 2
-    self._provide_item(env.realm, ent_id, Item.Scrap, level=0, quantity=3)
-    self._provide_item(env.realm, ent_id, Item.Scrap, level=1, quantity=3)
+    provide_item(env.realm, ent_id, Item.Scrap, level=0, quantity=3)
+    provide_item(env.realm, ent_id, Item.Scrap, level=1, quantity=3)
 
     # provide extra scrap to mage to make its inventory full
     # there will be no overlapping item
     ent_id = 3
-    self._provide_item(env.realm, ent_id, Item.Scrap, level=5, quantity=3)
-    self._provide_item(env.realm, ent_id, Item.Scrap, level=7, quantity=3)
+    provide_item(env.realm, ent_id, Item.Scrap, level=5, quantity=3)
+    provide_item(env.realm, ent_id, Item.Scrap, level=7, quantity=3)
     env.obs = env._compute_observations()
 
     # First tick actions: SELL level-0 ammo
@@ -166,8 +166,8 @@ class TestAmmoUse(ScriptedTestTemplate):
 
     for ent_id in self.policy:
       # provide extra scrap 
-      self._provide_item(env.realm, ent_id, Item.Scrap, level=0, quantity=extra_ammo)
-      self._provide_item(env.realm, ent_id, Item.Scrap, level=1, quantity=extra_ammo)
+      provide_item(env.realm, ent_id, Item.Scrap, level=0, quantity=extra_ammo)
+      provide_item(env.realm, ent_id, Item.Scrap, level=1, quantity=extra_ammo)
 
     # level up the agent 1 (Melee) to 2
     env.realm.players[1].skills.melee.level.update(2)

--- a/tests/action/test_destroy_give_gold.py
+++ b/tests/action/test_destroy_give_gold.py
@@ -2,7 +2,7 @@ import unittest
 import logging
 
 # pylint: disable=import-error
-from testhelpers import ScriptedTestTemplate
+from testhelpers import ScriptedTestTemplate, change_spawn_pos, provide_item
 
 from nmmo.io import action
 from nmmo.systems import item as Item
@@ -95,7 +95,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     env = self._setup_env(random_seed=RANDOM_SEED)
 
     # teleport the npc -1 to agent 5's location
-    self._change_spawn_pos(env.realm, -1, self.spawn_locs[5])
+    change_spawn_pos(env.realm, -1, self.spawn_locs[5])
     env.obs = env._compute_observations()
 
     """ First tick actions """
@@ -205,7 +205,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     for ent_id in [1, 2]:
       for item_sig in extra_items:
         self.item_sig[ent_id].append(item_sig)
-        self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
+        provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
 
     env.obs = env._compute_observations()
 
@@ -250,7 +250,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     env = self._setup_env(random_seed=RANDOM_SEED)
 
     # teleport the npc -1 to agent 3's location
-    self._change_spawn_pos(env.realm, -1, self.spawn_locs[3])
+    change_spawn_pos(env.realm, -1, self.spawn_locs[3])
     env.obs = env._compute_observations()
 
     test_cond = {}

--- a/tests/action/test_sell_buy.py
+++ b/tests/action/test_sell_buy.py
@@ -2,7 +2,7 @@ import unittest
 import logging
 
 # pylint: disable=import-error
-from testhelpers import ScriptedTestTemplate
+from testhelpers import ScriptedTestTemplate, provide_item
 
 from nmmo.io import action
 from nmmo.systems import item as Item
@@ -46,7 +46,7 @@ class TestSellBuy(ScriptedTestTemplate):
     for ent_id in [1, 2]:
       for item_sig in extra_items:
         self.item_sig[ent_id].append(item_sig)
-        self._provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
+        provide_item(env.realm, ent_id, item_sig[0], item_sig[1], 1)
 
     env.obs = env._compute_observations()
 


### PR DESCRIPTION
* When Item is initialized "normally" in the game, (for example harvesting ammo or npcs dropping armor/weapon) there is no case where quantity > 1. So the quantity arg was deleted in the Item.__init__()
  * This does not interfere with looting ammos (quantity > 1) because it does not create a new item instance but just transfers the existing item instance.
* Pulled `provide_item()` and `change_spawn_pos()` functions from the class, as these were also used when testing predicates.
* Made `Observation.tile()` return lava, to make the statements like `if ob.tile(-1, 0).material_id in material.Habitable:` work without modifying it.