### PR TITLE
Pytest, pylint-related changes

### DIFF
--- a/.github/workflows/pylint-test.yml
+++ b/.github/workflows/pylint-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Running unit tests
       run: pytest
     - name: Analysing the code with pylint
-      run: pylint --rcfile=pylint.cfg --recursive=y nmmo tests
+      run: pylint --recursive=y nmmo tests
     - name: Looking for xcxc, just in case
       run: |
         if grep -r --include='*.py' 'xcxc'; then

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,6 +7,7 @@ disable=W0511, # TODO/FIXME
         C0116, # missing function docstring
         W0221, # arguments differ from overridden method
         C0415, # import outside toplevel
+        E0611, # no name in module
         R0901, # too many ancestors
         R0902, # too many instance attributes
         R0903, # too few public methods

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 # pytest.ini
 [pytest]
-python_paths = . tests
+python_paths = .

--- a/scripts/pre-git-check.sh
+++ b/scripts/pre-git-check.sh
@@ -7,9 +7,20 @@ echo
 # Run linter
 echo "--------------------------------------------------------------------"
 echo "Running linter..."
-if ! pylint --rcfile=pylint.cfg --fail-under=10 nmmo tests; then
-    echo "Lint failed. Exiting."
-    exit 1
+files=$(git ls-files -m -o --exclude-standard '*.py')
+for file in $files; do
+  if test -e $file; then
+    echo $file
+    if ! pylint --score=no --fail-under=10 $file; then
+      echo "Lint failed. Exiting."
+      exit 1
+    fi
+  fi
+done
+
+if ! pylint --recursive=y nmmo tests; then
+  echo "Lint failed. Exiting."
+  exit 1
 fi
 
 # Check if there are any "xcxc" strings in the code

--- a/tests/action/test_destroy_give_gold.py
+++ b/tests/action/test_destroy_give_gold.py
@@ -1,8 +1,7 @@
 import unittest
 import logging
 
-# pylint: disable=import-error
-from testhelpers import ScriptedTestTemplate, change_spawn_pos, provide_item
+from tests.testhelpers import ScriptedTestTemplate, change_spawn_pos, provide_item
 
 from nmmo.io import action
 from nmmo.systems import item as Item
@@ -14,6 +13,8 @@ RANDOM_SEED = 985
 LOGFILE = 'tests/action/test_destroy_give_gold.log'
 
 class TestDestroyGiveGold(ScriptedTestTemplate):
+  # pylint: disable=protected-access,multiple-statements
+
   @classmethod
   def setUpClass(cls):
     super().setUpClass()
@@ -24,7 +25,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
 
     cls.policy = { 1:'Melee', 2:'Range', 3:'Melee', 4:'Range', 5:'Melee', 6:'Range' }
     cls.spawn_locs = { 1:(17,17), 2:(21,21), 3:(17,17), 4:(21,21), 5:(21,21), 6:(17,17) }
-    cls.ammo = { 1:Item.Scrap, 2:Item.Shaving, 3:Item.Scrap, 
+    cls.ammo = { 1:Item.Scrap, 2:Item.Shaving, 3:Item.Scrap,
                  4:Item.Shaving, 5:Item.Scrap, 6:Item.Shaving }
 
     cls.config.LOG_VERBOSE = False
@@ -43,10 +44,10 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     # this should be marked in the mask too
 
     """ First tick """ # First tick actions: USE (equip) level-0 ammo
-    env.step({ ent_id: { action.Use: { action.InventoryItem: 
+    env.step({ ent_id: { action.Use: { action.InventoryItem:
         env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][0]) } # level-0 ammo
       } for ent_id in self.policy })
-    
+
     # check if the agents have equipped the ammo
     for ent_id in self.policy:
       ent_obs = env.obs[ent_id]
@@ -64,15 +65,15 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
 
     """ Second tick """ # Second tick actions: DESTROY ammo
     actions = {}
-    
+
     for ent_id in self.policy:
       if ent_id in [1, 2]:
         # agent 1 & 2, destroy the level-3 ammos, which are valid
-        actions[ent_id] = { action.Destroy: 
+        actions[ent_id] = { action.Destroy:
           { action.InventoryItem: env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][1]) } }
       else:
         # other agents: destroy the equipped level-0 ammos, which are invalid
-        actions[ent_id] = { action.Destroy: 
+        actions[ent_id] = { action.Destroy:
           { action.InventoryItem: env.obs[ent_id].inventory.sig(*self.item_sig[ent_id][0]) } }
     env.step(actions)
 
@@ -125,7 +126,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     for ent_id, cond in test_cond.items():
       self.assertEqual( cond['valid'],
         env.obs[ent_id].inventory.sig(*cond['item_sig']) is None)
-      
+
       if ent_id == 1: # agent 1 gave ammo stack to agent 3
         tgt_inv = env.obs[cond['tgt_id']].inventory
         inv_idx = tgt_inv.sig(*cond['item_sig'])
@@ -145,15 +146,15 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     # agent 1: equip the ammo
     ent_id = 1; item_sig = self.item_sig[ent_id][0]
     self.assertTrue(
-      self._check_inv_mask(env.obs[ent_id], action.Use, item_sig)) 
-    actions[ent_id] = { action.Use: { action.InventoryItem: 
+      self._check_inv_mask(env.obs[ent_id], action.Use, item_sig))
+    actions[ent_id] = { action.Use: { action.InventoryItem:
         env.obs[ent_id].inventory.sig(*item_sig) } }
 
     # agent 2: list the ammo for sale
     ent_id = 2; price = 5; item_sig = self.item_sig[ent_id][0]
     self.assertTrue(
-      self._check_inv_mask(env.obs[ent_id], action.Sell, item_sig)) 
-    actions[ent_id] = { action.Sell: { 
+      self._check_inv_mask(env.obs[ent_id], action.Sell, item_sig))
+    actions[ent_id] = { action.Sell: {
         action.InventoryItem: env.obs[ent_id].inventory.sig(*item_sig),
         action.Price: price } }
 
@@ -196,7 +197,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     # DONE
 
   def test_give_full_inventory(self):
-    # cannot give to an agent with the full inventory, 
+    # cannot give to an agent with the full inventory,
     #   but it's possible if the agent has the same ammo stack
     env = self._setup_env(random_seed=RANDOM_SEED)
 
@@ -233,7 +234,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
     for ent_id, cond in test_cond.items():
       self.assertEqual( cond['valid'],
         env.obs[ent_id].inventory.sig(*cond['item_sig']) is None)
-      
+
       if ent_id == 3: # successfully gave the ammo stack to agent 1
         tgt_inv = env.obs[cond['tgt_id']].inventory
         inv_idx = tgt_inv.sig(*cond['item_sig'])
@@ -257,7 +258,7 @@ class TestDestroyGiveGold(ScriptedTestTemplate):
 
     # NOTE: the below tests rely on the static execution order from 1 to N
     # agent 1: give gold to agent 3 (valid: the same team, same tile)
-    test_cond[1] = { 'tgt_id': 3, 'gold': 1, 'ent_mask': True, 
+    test_cond[1] = { 'tgt_id': 3, 'gold': 1, 'ent_mask': True,
                      'ent_gold': self.init_gold-1, 'tgt_gold': self.init_gold+1 }
     # agent 2: give gold to agent 4 (valid: the same team, same tile)
     test_cond[2] = { 'tgt_id': 4, 'gold': 100, 'ent_mask': True,

--- a/tests/action/test_monkey_action.py
+++ b/tests/action/test_monkey_action.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 
 import numpy as np
 
-from testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
+from tests.testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
 
 import nmmo
 
@@ -37,7 +37,7 @@ class TestMonkeyAction(unittest.TestCase):
   def test_monkey_action(self):
     env = ScriptedAgentTestEnv(self.config)
     obs = env.reset(seed=RANDOM_SEED)
-    
+
     # the goal is just to run TEST_HORIZON without runtime errors
     # TODO(kywch): add more sophisticate/correct action validation tests
     #   for example, one cannot USE/SELL/GIVE/DESTORY the same item

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -6,8 +6,8 @@ import random
 from tqdm import tqdm
 
 # pylint: disable=import-error
-from testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
-from testhelpers import observations_are_equal, actions_are_equal
+from tests.testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
+from tests.testhelpers import observations_are_equal, actions_are_equal
 
 # 30 seems to be enough to test variety of agent actions
 TEST_HORIZON = 30

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -5,7 +5,6 @@ import logging
 import random
 from tqdm import tqdm
 
-# pylint: disable=import-error
 from tests.testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
 from tests.testhelpers import observations_are_equal, actions_are_equal
 

--- a/tests/test_deterministic_replay.py
+++ b/tests/test_deterministic_replay.py
@@ -12,7 +12,8 @@ import numpy as np
 from tqdm import tqdm
 
 # pylint: disable=import-error
-from testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv, observations_are_equal
+from tests.testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
+from tests.testhelpers import observations_are_equal
 
 import nmmo
 

--- a/tests/test_deterministic_replay.py
+++ b/tests/test_deterministic_replay.py
@@ -11,7 +11,6 @@ from typing import Any, Dict
 import numpy as np
 from tqdm import tqdm
 
-# pylint: disable=import-error
 from tests.testhelpers import ScriptedAgentTestConfig, ScriptedAgentTestEnv
 from tests.testhelpers import observations_are_equal
 


### PR DESCRIPTION
This PR re-did pytest/pylint-related changes in the `event-log`. There is no changes in logic.
* pylint.cfg was renamed to .pylintrc (the default config file name), so we can run `pylint` without the --rcfile flag.
* added `E0611, # no name in module` to the ignore list, which is false alarm. (If true, the script won't run and tests would fail)
* fixed the pylint blind spot in the `pre-git-check.sh` 
* fixed the pylint complaints