### PR TITLE
fixed an item bug caused by inconsistent item instance <-> datastore

### DIFF
--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -296,8 +296,7 @@ class Entity(EntityState):
     if source is None or not source.is_player: # nobody or npcs cannot loot
       if self.config.ITEM_SYSTEM_ENABLED:
         for item in list(self.inventory.items):
-          self.inventory.remove(item) # delete from the inventory/market
-          item.destroy() # delete from the datastore
+          item.destroy()
       return False
 
     # now, source can loot the dead self

--- a/nmmo/io/action.py
+++ b/nmmo/io/action.py
@@ -369,7 +369,7 @@ class Use(Node):
     return config.ITEM_SYSTEM_ENABLED
 
   def call(realm, entity, item):
-    if item is None:
+    if item is None or item.is_void:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -399,7 +399,7 @@ class Destroy(Node):
     return config.ITEM_SYSTEM_ENABLED
 
   def call(realm, entity, item):
-    if item is None:
+    if item is None or item.is_void:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -415,8 +415,6 @@ class Destroy(Node):
     if item.equipped.val: # cannot destroy equipped item
       return
 
-    # inventory.remove() also unlists the item, if it has been listed
-    entity.inventory.remove(item)
     item.destroy()
 
     realm.event_log.record(EventCode.DESTROY_ITEM, entity)
@@ -432,7 +430,7 @@ class Give(Node):
     return config.ITEM_SYSTEM_ENABLED
 
   def call(realm, entity, item, target):
-    if item is None or target is None:
+    if item is None or item.is_void or target is None:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -552,7 +550,7 @@ class Buy(Node):
     return config.EXCHANGE_SYSTEM_ENABLED
 
   def call(realm, entity, item):
-    if item is None:
+    if item is None or item.is_void:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -593,7 +591,7 @@ class Sell(Node):
     return config.EXCHANGE_SYSTEM_ENABLED
 
   def call(realm, entity, item, price):
-    if item is None or price is None:
+    if item is None or item.is_void or price is None:
       return
 
     assert entity.alive, "Dead entity cannot act"

--- a/nmmo/io/action.py
+++ b/nmmo/io/action.py
@@ -369,7 +369,7 @@ class Use(Node):
     return config.ITEM_SYSTEM_ENABLED
 
   def call(realm, entity, item):
-    if item is None or item.is_void:
+    if item is None or item.owner_id.val != entity.ent_id:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -399,7 +399,7 @@ class Destroy(Node):
     return config.ITEM_SYSTEM_ENABLED
 
   def call(realm, entity, item):
-    if item is None or item.is_void:
+    if item is None or item.owner_id.val != entity.ent_id:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -430,7 +430,7 @@ class Give(Node):
     return config.ITEM_SYSTEM_ENABLED
 
   def call(realm, entity, item, target):
-    if item is None or item.is_void or target is None:
+    if item is None or item.owner_id.val != entity.ent_id or target is None:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -550,7 +550,7 @@ class Buy(Node):
     return config.EXCHANGE_SYSTEM_ENABLED
 
   def call(realm, entity, item):
-    if item is None or item.is_void:
+    if item is None or item.owner_id.val == 0:
       return
 
     assert entity.alive, "Dead entity cannot act"
@@ -591,7 +591,7 @@ class Sell(Node):
     return config.EXCHANGE_SYSTEM_ENABLED
 
   def call(realm, entity, item, price):
-    if item is None or item.is_void or price is None:
+    if item is None or item.owner_id.val != entity.ent_id or price is None:
       return
 
     assert entity.alive, "Dead entity cannot act"

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -118,7 +118,20 @@ class Item(ItemState):
   @property
   def is_void(self):
     # test if the linked datastore record is deleted
-    return len(ItemState.Query.by_id(self.realm.datastore, self.id.val)) == 0
+    item_arr = ItemState.Query.by_id(self.realm.datastore, self.id.val)
+    if len(item_arr) == 0:
+      return True
+
+    # if there is a datastore record, see if it is the same item type
+    item = ItemState.parse_array(item_arr[0])
+    if item.owner_id == self.owner_id.val and \
+       item.type_id == self.ITEM_TYPE_ID and \
+       item.level == self.level.val and \
+       item.quantity == self.quantity.val:
+      return False # valid item
+
+    # the info does not match, perhaps a new entry was created with the same id
+    return True
 
   @property
   def packet(self):

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -116,24 +116,6 @@ class Item(ItemState):
     self.datastore_record.delete()
 
   @property
-  def is_void(self):
-    # test if the linked datastore record is deleted
-    item_arr = ItemState.Query.by_id(self.realm.datastore, self.id.val)
-    if len(item_arr) == 0:
-      return True
-
-    # if there is a datastore record, see if it is the same item type
-    item = ItemState.parse_array(item_arr[0])
-    if item.owner_id == self.owner_id.val and \
-       item.type_id == self.ITEM_TYPE_ID and \
-       item.level == self.level.val and \
-       item.quantity == self.quantity.val:
-      return False # valid item
-
-    # the info does not match, perhaps a new entry was created with the same id
-    return True
-
-  @property
   def packet(self):
     return {'item':             self.__class__.__name__,
             'level':            self.level.val,

--- a/nmmo/systems/item.py
+++ b/nmmo/systems/item.py
@@ -110,8 +110,15 @@ class Item(ItemState):
     realm.items[self.id.val] = self
 
   def destroy(self):
+    if self.owner_id.val in self.realm.players:
+      self.realm.players[self.owner_id.val].inventory.remove(self)
     self.realm.items.pop(self.id.val, None)
     self.datastore_record.delete()
+
+  @property
+  def is_void(self):
+    # test if the linked datastore record is deleted
+    return len(ItemState.Query.by_id(self.realm.datastore, self.id.val)) == 0
 
   @property
   def packet(self):

--- a/tests/action/test_monkey_action.py
+++ b/tests/action/test_monkey_action.py
@@ -10,7 +10,49 @@ import nmmo
 
 # 30 seems to be enough to test variety of agent actions
 TEST_HORIZON = 30
-RANDOM_SEED = random.randint(0, 10000)
+RANDOM_SEED = random.randint(0, 1000000)
+
+
+def make_random_actions(config, ent_obs):
+  assert 'ActionTargets' in ent_obs, 'ActionTargets is not provided in the obs'
+  actions = {}
+
+  # atn, arg, val
+  for atn in sorted(nmmo.Action.edges(config)):
+    actions[atn] = {}
+    for arg in sorted(atn.edges, reverse=True): # intentionally doing wrong
+      mask = ent_obs['ActionTargets'][atn][arg]
+      actions[atn][arg] = 0
+      if np.any(mask):
+        actions[atn][arg] += int(np.random.choice(np.where(mask)[0]))
+
+  return actions
+
+# CHECK ME: this would be nice to include in the env._validate_actions()
+def filter_item_actions(actions):
+  # when there are multiple actions on the same item, select one
+  flt_atns = {}
+  inventory_atn = {} # key: inventory idx, val: action
+  for atn in actions:
+    if atn in [nmmo.action.Use, nmmo.action.Sell, nmmo.action.Give, nmmo.action.Destroy]:
+      for arg, val in actions[atn].items():
+        if arg == nmmo.action.InventoryItem:
+          if val not in inventory_atn:
+            inventory_atn[val] = [( atn, actions[atn] )]
+          else:
+            inventory_atn[val].append(( atn, actions[atn] ))
+    else:
+      flt_atns[atn] = actions[atn]
+
+    # randomly select one action for each inventory item
+    for atns in inventory_atn.values():
+      if len(atns) > 1:
+        picked = random.choice(atns)
+        flt_atns[picked[0]] = picked[1]
+      else:
+        flt_atns[atns[0][0]] = atns[0][1]
+
+    return flt_atns
 
 
 class TestMonkeyAction(unittest.TestCase):
@@ -19,37 +61,25 @@ class TestMonkeyAction(unittest.TestCase):
     cls.config = ScriptedAgentTestConfig()
     cls.config.PROVIDE_ACTION_TARGETS = True
 
-  def _make_random_actions(self, ent_obs):
-    assert 'ActionTargets' in ent_obs, 'ActionTargets is not provided in the obs'
-    actions = {}
+  @staticmethod
+  # NOTE: this can also be used for sweeping random seeds
+  def rollout_with_seed(config, seed):
+    env = ScriptedAgentTestEnv(config)
+    obs = env.reset(seed=seed)
 
-    # atn, arg, val
-    for atn in sorted(nmmo.Action.edges(self.config)):
-      actions[atn] = {}
-      for arg in sorted(atn.edges, reverse=True): # intentionally doing wrong
-        mask = ent_obs['ActionTargets'][atn][arg]
-        actions[atn][arg] = 0
-        if np.any(mask):
-          actions[atn][arg] += int(np.random.choice(np.where(mask)[0]))
-
-    return actions
-
-  def test_monkey_action(self):
-    env = ScriptedAgentTestEnv(self.config)
-    obs = env.reset(seed=RANDOM_SEED)
-
-    # the goal is just to run TEST_HORIZON without runtime errors
-    # TODO(kywch): add more sophisticate/correct action validation tests
-    #   for example, one cannot USE/SELL/GIVE/DESTORY the same item
-    #   this will not produce an runtime error, but agents should not do that
     for _ in tqdm(range(TEST_HORIZON)):
       # sample random actions for each player
       actions = {}
       for ent_id in env.realm.players:
-        actions[ent_id] = self._make_random_actions(obs[ent_id])
+        ent_atns = make_random_actions(config, obs[ent_id])
+        actions[ent_id] = filter_item_actions(ent_atns)
       obs, _, _, _ = env.step(actions)
 
-    # DONE
+  def test_monkey_action(self):
+    try:
+      self.rollout_with_seed(self.config, RANDOM_SEED)
+    except: # pylint: disable=bare-except
+      assert False, f"Monkey action failed. seed: {RANDOM_SEED}"
 
 
 if __name__ == '__main__':

--- a/tests/systems/test_item.py
+++ b/tests/systems/test_item.py
@@ -34,11 +34,11 @@ class TestItem(unittest.TestCase):
     # also test destroy
     ids = [hat_1.id.val, hat_2.id.val]
     hat_1.destroy()
-    # after destroy(), the datastore entry is gone, but the class still exsits
-    self.assertEqual(hat_1.is_void, True)
-    self.assertEqual(hat_2.is_void, False)
-
     hat_2.destroy()
+    # after destroy(), the datastore entry is gone, but the class still exsits
+    # make sure that after destroy the owner_id is 0, at least
+    self.assertTrue(hat_1.owner_id.val == 0)
+    self.assertTrue(hat_2.owner_id.val == 0)
     for item_id in ids:
       self.assertTrue(len(ItemState.Query.by_id(realm.datastore, item_id)) == 0)
     self.assertDictEqual(realm.items, {})
@@ -46,7 +46,9 @@ class TestItem(unittest.TestCase):
     # create a new item with the hat_1's id, but it must still be void
     new_top = Top(realm, 3)
     new_top.id.update(ids[0]) # hat_1's id
-    self.assertEqual(hat_1.is_void, True) # hat_1 is still void
+    new_top.owner_id.update(100)
+    # make sure that the hat_1 is not linked to the new_top
+    self.assertTrue(hat_1.owner_id.val == 0)
 
   def test_owned_by(self):
     realm = MockRealm()

--- a/tests/systems/test_item.py
+++ b/tests/systems/test_item.py
@@ -1,8 +1,9 @@
 import unittest
+import numpy as np
+
 import nmmo
 from nmmo.datastore.numpy_datastore import NumpyDatastore
 from nmmo.systems.item import Hat, ItemState
-import numpy as np
 
 class MockRealm:
   def __init__(self):
@@ -10,7 +11,9 @@ class MockRealm:
     self.datastore = NumpyDatastore()
     self.items = {}
     self.datastore.register_object_type("Item", ItemState.State.num_attributes)
+    self.players = {}
 
+# pylint: disable=no-member
 class TestItem(unittest.TestCase):
   def test_item(self):
     realm = MockRealm()
@@ -46,10 +49,10 @@ class TestItem(unittest.TestCase):
     hat_2.owner_id.update(1)
 
     np.testing.assert_array_equal(
-      ItemState.Query.owned_by(realm.datastore, 1)[:,0], 
+      ItemState.Query.owned_by(realm.datastore, 1)[:,0],
       [hat_1.id.val, hat_2.id.val])
 
     self.assertEqual(Hat.Query.owned_by(realm.datastore, 2).size, 0)
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/tests/systems/test_item.py
+++ b/tests/systems/test_item.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import nmmo
 from nmmo.datastore.numpy_datastore import NumpyDatastore
-from nmmo.systems.item import Hat, ItemState
+from nmmo.systems.item import Hat, Top, ItemState
 
 class MockRealm:
   def __init__(self):
@@ -34,10 +34,19 @@ class TestItem(unittest.TestCase):
     # also test destroy
     ids = [hat_1.id.val, hat_2.id.val]
     hat_1.destroy()
+    # after destroy(), the datastore entry is gone, but the class still exsits
+    self.assertEqual(hat_1.is_void, True)
+    self.assertEqual(hat_2.is_void, False)
+
     hat_2.destroy()
     for item_id in ids:
       self.assertTrue(len(ItemState.Query.by_id(realm.datastore, item_id)) == 0)
     self.assertDictEqual(realm.items, {})
+
+    # create a new item with the hat_1's id, but it must still be void
+    new_top = Top(realm, 3)
+    new_top.id.update(ids[0]) # hat_1's id
+    self.assertEqual(hat_1.is_void, True) # hat_1 is still void
 
   def test_owned_by(self):
     realm = MockRealm()


### PR DESCRIPTION
* `item.destroy()` also handles `entity.inventory.remove(item)`
* there were cases where an item instance's datastore row is deleted (by `item.destroy()`) but the instance still existed and caused problems. So the `Item.is_void()` is added to check if the linked datastore entry is available and has the same info.
*  Use/Destroy/Give/Sell check is the provided item is not void, as well as not none.
* `test_monkey_actions.py` was refactored to support random seed sweeps
* `test_item.py`  got new tests for is_void and linted.
