### PR TITLE
fixed render packet

### DIFF
--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -193,21 +193,9 @@ class History:
     if self.attack is not None:
       data['attack'] = self.attack
 
-    actions = {}
-    for atn, args in self.actions.items():
-      atn_packet = {}
-
-      # Avoid recursive player packet
-      if atn.__name__ == 'Attack':
-        continue
-
-      for key, val in args.items():
-        if hasattr(val, 'packet'):
-          atn_packet[key.__name__] = val.packet
-        else:
-          atn_packet[key.__name__] = val.__name__
-      actions[atn.__name__] = atn_packet
-    data['actions'] = actions
+    # NOTE: the client seems to use actions for visualization
+    #   but produces errors with the new actions. So we disable it for now.
+    data['actions'] = {}
 
     return data
 

--- a/scripted/baselines.py
+++ b/scripted/baselines.py
@@ -79,17 +79,18 @@ class Scripted(nmmo.Agent):
 
   def target_weak(self):
     '''Target the nearest agent if it is weak'''
-    # disabled for now
-    # if self.closest is None:
-    #   return False
+    if self.closest is None:
+      return False
 
-    # selfLevel  = self.me.level
-    # targLevel  = max(self.closest.melee_level, self.closest.range_level, self.closest.mage_level)
+    selfLevel  = self.me.level
+    targLevel  = max(self.closest.melee_level, self.closest.range_level, self.closest.mage_level)
 
-    # if population == -1 or targLevel <= selfLevel <= 5 or selfLevel >= targLevel + 3:
-    #   self.target     = self.closest
-    #   self.targetID   = self.closestID
-    #   self.targetDist = self.closestDist
+    if self.closest.npc_type == 1 or \
+       targLevel <= selfLevel <= 5 or \
+       selfLevel >= targLevel + 3:
+      self.target     = self.closest
+      self.targetID   = self.closestID
+      self.targetDist = self.closestDist
 
   def scan_agents(self):
     '''Scan the nearby area for agents'''

--- a/tests/render/test_render_save.py
+++ b/tests/render/test_render_save.py
@@ -2,20 +2,22 @@
 
 if __name__ == '__main__':
   import time
+  import random
   import nmmo
 
   # pylint: disable=import-error
   from nmmo.render.render_client import WebsocketRenderer
   from tests.testhelpers import ScriptedAgentTestConfig
 
-  TEST_HORIZON = 30
+  TEST_HORIZON = 100
+  RANDOM_SEED = random.randint(0, 9999)
 
   # config.RENDER option is gone,
   # RENDER can be done without setting any config
   config = ScriptedAgentTestConfig()
   env = nmmo.Env(config)
 
-  env.reset()
+  env.reset(seed=RANDOM_SEED)
 
   # the renderer is external to the env, so need to manually initiate it
   renderer = WebsocketRenderer(env.realm)
@@ -26,4 +28,4 @@ if __name__ == '__main__':
     time.sleep(1)
 
   # save the packet: this is possible because config.SAVE_REPLAY = True
-  env.realm.save_replay('replay_dev.json', compress=False)
+  env.realm.save_replay(f'replay_seed_{RANDOM_SEED:04d}.json', compress=False)


### PR DESCRIPTION
* The client seems to use entity.history.packet['actions'] for some action visualization other than move and attack, but cannot process the new format for buy/sell/etc. So the empty {} is returned there to avoid error 
  * Now, the client can render move and attack without any problem.
* scripted agent's targeting weak logic was fixed.
