### PR TITLE
generate new maps if all maps are not present

### DIFF
--- a/nmmo/core/terrain.py
+++ b/nmmo/core/terrain.py
@@ -237,8 +237,20 @@ class MapGenerator:
     #Only generate if maps are not cached
     path_maps = os.path.join(config.PATH_CWD, config.PATH_MAPS)
     os.makedirs(path_maps, exist_ok=True)
+
     if not config.MAP_FORCE_GENERATION and os.listdir(path_maps):
-      return
+      # check if the folder has all the required maps
+      all_maps_exist = True
+      for idx in range(config.MAP_N, -1, -1):
+        map_file = path_maps + '/map' + str(idx+1) + '/map.npy'
+        if not os.path.exists(map_file):
+          # override MAP_FORCE_GENERATION = FALSE and generate maps
+          all_maps_exist = False
+          break
+
+      # do not generate maps if all maps exist
+      if all_maps_exist:
+        return
 
     if __debug__:
       logging.info('Generating %s maps', str(config.MAP_N))

--- a/tests/core/test_map_generation.py
+++ b/tests/core/test_map_generation.py
@@ -1,0 +1,28 @@
+import unittest
+import os
+import shutil
+
+import nmmo
+
+class TestMapGeneration(unittest.TestCase):
+  def test_insufficient_maps(self):
+    config = nmmo.config.Small()
+    config.MAP_N = 20
+
+    path_maps = os.path.join(config.PATH_CWD, config.PATH_MAPS)
+    shutil.rmtree(path_maps)
+
+    # this generates 20 maps
+    nmmo.Env(config)
+
+    # test if MAP_FORCE_GENERATION can be overriden
+    config.MAP_N = 30
+    config.MAP_FORCE_GENERATION = False
+
+    test_env = nmmo.Env(config)
+    test_env.reset(map_id = 25)
+
+    # this should finish without error
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
* If there are missing maps with respect to the given `config.MAP_N`, generate new maps regardless of `config.MAP_FORCE_GENERATION`