### PR TITLE
determinism needs datastore id alloc reset

### DIFF
--- a/nmmo/core/realm.py
+++ b/nmmo/core/realm.py
@@ -86,6 +86,10 @@ class Realm:
     assert ItemState.State.table(self.datastore).is_empty(), \
         "ItemState table is not empty"
 
+    # DataStore id allocator must be reset to be deterministic
+    EntityState.State.table(self.datastore).reset()
+    ItemState.State.table(self.datastore).reset()
+
     self.players.spawn()
     self.npcs.spawn()
     self.tick = 0


### PR DESCRIPTION
Not resetting the datastore's id allocator can break determinism because the id allocators can have different max_id, frees between the initial and subsequent runs.