### PR TITLE
fixed dones bug, added team spawn, loot item shuffle

### DIFF
--- a/nmmo/core/env.py
+++ b/nmmo/core/env.py
@@ -15,7 +15,6 @@ from nmmo.core.observation import Observation
 from nmmo.core.tile import Tile
 from nmmo.entity.entity import Entity
 from nmmo.systems.item import Item
-from nmmo.lib.team_helper import TeamHelper
 from nmmo.task.game_state import GameStateGenerator
 from nmmo.task.task_api import Task
 from nmmo.task.scenario import default_task
@@ -27,15 +26,13 @@ class Env(ParallelEnv):
   #pylint: disable=no-value-for-parameter
   def __init__(self,
                config: Default = nmmo.config.Default(),
-               seed = None,
-               team_helper: TeamHelper = None):
+               seed = None):
     self._init_random(seed)
 
     super().__init__()
 
     self.config = config
-    self.team_helper = team_helper
-    self.realm = realm.Realm(config, team_helper=team_helper)
+    self.realm = realm.Realm(config)
     self.obs = None
 
     self.possible_agents = list(range(1, config.PLAYER_N + 1))

--- a/nmmo/core/realm.py
+++ b/nmmo/core/realm.py
@@ -17,6 +17,7 @@ from nmmo.datastore.numpy_datastore import NumpyDatastore
 from nmmo.systems.exchange import Exchange
 from nmmo.systems.item import Item, ItemState
 from nmmo.lib.event_log import EventLogger, EventState
+from nmmo.lib.team_helper import TeamHelper
 from nmmo.render.replay_helper import ReplayHelper
 
 def prioritized(entities: Dict, merged: Dict):
@@ -30,7 +31,8 @@ def prioritized(entities: Dict, merged: Dict):
 class Realm:
   """Top-level world object"""
 
-  def __init__(self, config):
+  def __init__(self, config,
+               team_helper: TeamHelper = None):
     self.config = config
     assert isinstance(
         config, nmmo.config.Config
@@ -55,6 +57,7 @@ class Realm:
     self.event_log = EventLogger(self)
 
     # Entity handlers
+    self.team_helper = team_helper
     self.players = PlayerManager(self)
     self.npcs = NPCManager(self)
 

--- a/nmmo/core/realm.py
+++ b/nmmo/core/realm.py
@@ -17,7 +17,6 @@ from nmmo.datastore.numpy_datastore import NumpyDatastore
 from nmmo.systems.exchange import Exchange
 from nmmo.systems.item import Item, ItemState
 from nmmo.lib.event_log import EventLogger, EventState
-from nmmo.lib.team_helper import TeamHelper
 from nmmo.render.replay_helper import ReplayHelper
 
 def prioritized(entities: Dict, merged: Dict):
@@ -31,8 +30,7 @@ def prioritized(entities: Dict, merged: Dict):
 class Realm:
   """Top-level world object"""
 
-  def __init__(self, config,
-               team_helper: TeamHelper = None):
+  def __init__(self, config):
     self.config = config
     assert isinstance(
         config, nmmo.config.Config
@@ -57,7 +55,6 @@ class Realm:
     self.event_log = EventLogger(self)
 
     # Entity handlers
-    self.team_helper = team_helper
     self.players = PlayerManager(self)
     self.npcs = NPCManager(self)
 

--- a/nmmo/entity/entity_manager.py
+++ b/nmmo/entity/entity_manager.py
@@ -156,6 +156,17 @@ class PlayerManager(EntityGroup):
     super().spawn(player)
 
   def spawn(self):
+    # perform team spawn if team helper is provided
+    if self.realm.team_helper is not None:
+      spawn_locs = spawn.spawn_team_together(self.config, self.realm)
+      for team_id, team_members in self.realm.team_helper.teams.items():
+        r, c = spawn_locs[team_id]
+        for agent_id in team_members:
+          self.spawned.add(agent_id)
+          self.spawn_individual(r, c, agent_id)
+      return
+
+    # run the legacy code when team helper is None (no team)
     idx = 0
     for r, c in spawn.spawn_concurrent(self.config, self.realm):
       idx += 1

--- a/nmmo/entity/entity_manager.py
+++ b/nmmo/entity/entity_manager.py
@@ -141,7 +141,7 @@ class PlayerManager(EntityGroup):
   def __init__(self, realm):
     super().__init__(realm)
     self.loader  = self.realm.config.PLAYER_LOADER
-    self.agents = None
+    self.agents: spawn.SequentialLoader = None
     self.spawned = None
 
   def reset(self):
@@ -154,22 +154,13 @@ class PlayerManager(EntityGroup):
     agent      = agent(self.config, idx)
     player     = Player(self.realm, (r, c), agent)
     super().spawn(player)
+    self.spawned.add(idx)
 
   def spawn(self):
-    # perform team spawn if team helper is provided
-    if self.realm.team_helper is not None:
-      spawn_locs = spawn.spawn_team_together(self.config, self.realm)
-      for team_id, team_members in self.realm.team_helper.teams.items():
-        r, c = spawn_locs[team_id]
-        for agent_id in team_members:
-          self.spawned.add(agent_id)
-          self.spawn_individual(r, c, agent_id)
-      return
-
-    # run the legacy code when team helper is None (no team)
     idx = 0
-    for r, c in spawn.spawn_concurrent(self.config, self.realm):
+    while idx < self.config.PLAYER_N:
       idx += 1
+      r, c = self.agents.get_spawn_position(idx)
 
       if idx in self.entities:
         continue
@@ -177,5 +168,4 @@ class PlayerManager(EntityGroup):
       if idx in self.spawned:
         continue
 
-      self.spawned.add(idx)
       self.spawn_individual(r, c, idx)

--- a/nmmo/entity/entity_manager.py
+++ b/nmmo/entity/entity_manager.py
@@ -140,17 +140,17 @@ class NPCManager(EntityGroup):
 class PlayerManager(EntityGroup):
   def __init__(self, realm):
     super().__init__(realm)
-    self.loader  = self.realm.config.PLAYER_LOADER
-    self.agents: spawn.SequentialLoader = None
+    self.loader_class = self.realm.config.PLAYER_LOADER
+    self._agent_loader: spawn.SequentialLoader = None
     self.spawned = None
 
   def reset(self):
     super().reset()
-    self.agents  = self.loader(self.config)
+    self._agent_loader = self.loader_class(self.config)
     self.spawned = OrderedSet()
 
   def spawn_individual(self, r, c, idx):
-    agent = next(self.agents)
+    agent = next(self._agent_loader)
     agent      = agent(self.config, idx)
     player     = Player(self.realm, (r, c), agent)
     super().spawn(player)
@@ -160,7 +160,7 @@ class PlayerManager(EntityGroup):
     idx = 0
     while idx < self.config.PLAYER_N:
       idx += 1
-      r, c = self.agents.get_spawn_position(idx)
+      r, c = self._agent_loader.get_spawn_position(idx)
 
       if idx in self.entities:
         continue

--- a/nmmo/entity/npc.py
+++ b/nmmo/entity/npc.py
@@ -77,9 +77,6 @@ class NPC(entity.Entity):
     source.gold.increment(self.gold.val)
     self.gold.update(0)
 
-    # TODO(kywch): make source receive the highest-level items first
-    #   because source cannot take it if the inventory is full
-    #   Also, destroy the remaining items if the source cannot take those
     for item in self.droptable.roll(self.realm, self.attack_level):
       if source.is_player and source.inventory.space:
         source.inventory.receive(item)

--- a/nmmo/entity/player.py
+++ b/nmmo/entity/player.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from nmmo.systems.skill import Skills
 from nmmo.entity import entity
 
@@ -68,10 +70,11 @@ class Player(entity.Entity):
       source.gold.increment(self.gold.val)
       self.gold.update(0)
 
-    # TODO(kywch): make source receive the highest-level items first
+    # TODO: make source receive the highest-level items first
     #   because source cannot take it if the inventory is full
-    #   Also, destroy the remaining items if the source cannot take those
-    for item in list(self.inventory.items):
+    item_list = list(self.inventory.items)
+    np.random.shuffle(item_list)
+    for item in item_list:
       self.inventory.remove(item)
 
       # if source is None or NPC, destroy the item

--- a/nmmo/lib/spawn.py
+++ b/nmmo/lib/spawn.py
@@ -38,7 +38,25 @@ def spawn_continuous(config):
     r, c = c, r
   return (r, c)
 
+def get_edge_tiles(config):
+  '''Returns a list of all edge tiles'''
+  # Accounts for void borders in coord calcs
+  left = config.MAP_BORDER
+  right = config.MAP_CENTER + config.MAP_BORDER
+  lows = config.MAP_CENTER * [left]
+  highs = config.MAP_CENTER * [right]
+  inc = list(range(config.MAP_BORDER, config.MAP_CENTER+config.MAP_BORDER))
 
+  # All edge tiles in order
+  sides = []
+  sides.append(list(zip(lows, inc)))
+  sides.append(list(zip(inc, highs)))
+  sides.append(list(zip(highs, inc[::-1])))
+  sides.append(list(zip(inc[::-1], lows)))
+
+  return sides
+
+# TODO: consider removing this
 def spawn_concurrent(config, realm):
   '''Generates spawn positions for new agents
 
@@ -46,7 +64,7 @@ def spawn_concurrent(config, realm):
   of the square game map
 
   Returns:
-      tuple(int, int):
+      list of tuple(int, int):
 
   position:
       The position (row, col) to spawn the given agent
@@ -69,23 +87,10 @@ def spawn_concurrent(config, realm):
   # Number of tiles between teams
   team_sep = buffer_tiles // team_n
 
-  # Accounts for void borders in coord calcs
-  left = config.MAP_BORDER
-  right = config.MAP_CENTER + config.MAP_BORDER
-  lows = config.MAP_CENTER * [left]
-  highs = config.MAP_CENTER * [right]
-  inc = list(range(config.MAP_BORDER, config.MAP_CENTER+config.MAP_BORDER))
-
-  # All edge tiles in order
-  sides = []
-  sides += list(zip(lows, inc))
-  sides += list(zip(inc, highs))
-  sides += list(zip(highs, inc[::-1]))
-  sides += list(zip(inc[::-1], lows))
-  np.random.shuffle(sides)
-
-  # filter out invalid spawn positions
-  sides = [pos for pos in sides if not realm.map.tiles[pos].impassible]
+  merged = []
+  for side in get_edge_tiles(config):
+    merged += side
+  sides = [pos for pos in merged if not realm.map.tiles[pos].impassible]
 
   if team_n > 1:
     # Space across and within teams
@@ -94,11 +99,37 @@ def spawn_concurrent(config, realm):
       for offset in list(range(0,  tiles_per_team, teammate_sep+1)):
         if len(spawn_positions) >= config.PLAYER_N:
           continue
-
-        pos = sides[idx + offset]
+        pos = merged[idx + offset]
         spawn_positions.append(pos)
   else:
     # team_n = 1: to fit 128 agents in a small map, ignore spacing and spawn randomly
+    np.random.shuffle(sides)
     spawn_positions = sides[:config.PLAYER_N]
 
   return spawn_positions
+
+def spawn_team_together(config, realm):
+  '''Generates spawn positions for new teams
+  Agents in the same team spawn together in the same tile
+  Evenly spaces teams around the square map borders
+
+  Returns:
+      list of tuple(int, int):
+
+  position:
+      The position (row, col) to spawn the given teams
+  '''
+  num_teams = realm.team_helper.num_teams
+  teams_per_sides = (num_teams + 3) // 4 # 1-4 -> 1, 5-8 -> 2, etc.
+
+  sides = get_edge_tiles(config)
+  assert len(sides[0]) > 4*teams_per_sides, 'Map too small for teams'
+
+  team_spawn_positions = []
+  for side in sides:
+    for i in range(teams_per_sides):
+      idx = int(len(side)*(i+1)/(teams_per_sides + 1))
+      team_spawn_positions.append(side[idx])
+
+  np.random.shuffle(team_spawn_positions)
+  return team_spawn_positions

--- a/nmmo/lib/team_helper.py
+++ b/nmmo/lib/team_helper.py
@@ -1,0 +1,25 @@
+from typing import Dict, List
+
+
+class TeamHelper():
+  def __init__(self, teams: Dict[int, List[int]]):
+    self.teams = teams
+    self.num_teams = len(teams)
+    self.team_size = {}
+    self.team_and_position_for_agent = {}
+    self.agent_for_team_and_position = {}
+
+    for team_id, team in teams.items():
+      self.team_size[team_id] = len(team)
+      for position, agent_id in enumerate(team):
+        self.team_and_position_for_agent[agent_id] = (team_id, position)
+        self.agent_for_team_and_position[team_id, position] = agent_id
+
+  def agent_position(self, agent_id: int) -> int:
+    return self.team_and_position_for_agent[agent_id][1]
+
+  def agent_id(self, team_id: int, position: int) -> int:
+    return self.agent_for_team_and_position[team_id, position]
+
+  def is_agent_in_team(self, agent_id:int , team_id: int) -> bool:
+    return agent_id in self.teams[team_id]

--- a/tests/core/test_map_generation.py
+++ b/tests/core/test_map_generation.py
@@ -7,10 +7,11 @@ import nmmo
 class TestMapGeneration(unittest.TestCase):
   def test_insufficient_maps(self):
     config = nmmo.config.Small()
+    config.PATH_MAPS = 'maps/test_map_gen'
     config.MAP_N = 20
 
     path_maps = os.path.join(config.PATH_CWD, config.PATH_MAPS)
-    shutil.rmtree(path_maps)
+    shutil.rmtree(path_maps, ignore_errors=True)
 
     # this generates 20 maps
     nmmo.Env(config)
@@ -20,7 +21,7 @@ class TestMapGeneration(unittest.TestCase):
     config.MAP_FORCE_GENERATION = False
 
     test_env = nmmo.Env(config)
-    test_env.reset(map_id = 25)
+    test_env.reset(map_id=config.MAP_N)
 
     # this should finish without error
 

--- a/tests/test_team_spawn.py
+++ b/tests/test_team_spawn.py
@@ -1,20 +1,42 @@
 import unittest
 
 import nmmo
+from nmmo.core.agent import Agent
 from nmmo.lib.team_helper import TeamHelper
+from nmmo.lib import spawn
+
+
+class TeamLoader(spawn.SequentialLoader):
+  def __init__(self, config, team_helper: TeamHelper):
+    assert config.PLAYERS == [Agent], \
+      "TeamLoader only supports config.PLAYERS == [Agent]"
+    super().__init__(config)
+    self.team_helper = team_helper
+
+    self.candidate_spawn_pos = \
+      spawn.get_team_spawn_positions(config, team_helper.num_teams)
+
+  def get_spawn_position(self, agent_id):
+    team_id, _ = self.team_helper.team_and_position_for_agent[agent_id]
+    return self.candidate_spawn_pos[team_id]
+
 
 class TestTeamSpawn(unittest.TestCase):
   def test_team_spawn(self):
-    config = nmmo.config.Small()
     num_teams = 16
     team_size = 8
-
     team_helper = TeamHelper({
       i: [i*team_size+j+1 for j in range(team_size)]
       for i in range(num_teams)}
     )
 
-    env = nmmo.Env(config, team_helper=team_helper)
+    config = nmmo.config.Small()
+    config.PLAYER_N = num_teams * team_size
+    config.PLAYER_LOADER = lambda config: TeamLoader(config, team_helper)
+
+    assert config.PLAYER_N == num_teams * team_size,\
+      "config.PLAYER_N must be num_teams * team_size"
+    env = nmmo.Env(config)
     env.reset()
 
     # agents in the same team should spawn together

--- a/tests/test_team_spawn.py
+++ b/tests/test_team_spawn.py
@@ -1,0 +1,34 @@
+import unittest
+
+import nmmo
+from nmmo.lib.team_helper import TeamHelper
+
+class TestTeamSpawn(unittest.TestCase):
+  def test_team_spawn(self):
+    config = nmmo.config.Small()
+    num_teams = 16
+    team_size = 8
+
+    team_helper = TeamHelper({
+      i: [i*team_size+j+1 for j in range(team_size)]
+      for i in range(num_teams)}
+    )
+
+    env = nmmo.Env(config, team_helper=team_helper)
+    env.reset()
+
+    # agents in the same team should spawn together
+    team_locs = {}
+    for team_id, team_members in team_helper.teams.items():
+      team_locs[team_id] = env.realm.players[team_members[0]].pos
+      for agent_id in team_members:
+        self.assertEqual(team_locs[team_id], env.realm.players[agent_id].pos)
+
+    # teams should be apart from each other
+    for i in range(num_teams):
+      for j in range(i+1, num_teams):
+        self.assertNotEqual(team_locs[i], team_locs[j])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/utils/pre-git-check.sh
+++ b/utils/pre-git-check.sh
@@ -4,6 +4,9 @@ echo
 echo "Checking pylint, xcxc, pytest without touching git"
 echo
 
+# Check the number of physical cores only
+cores=$(lscpu -b -p=Core,Socket | grep -v '^#' | sort -u | wc -l)
+
 # Run linter
 echo "--------------------------------------------------------------------"
 echo "Running linter..."
@@ -18,7 +21,7 @@ for file in $files; do
   fi
 done
 
-if ! pylint --recursive=y nmmo tests; then
+if ! pylint --jobs=$cores --recursive=y nmmo tests; then
   echo "Lint failed. Exiting."
   exit 1
 fi


### PR DESCRIPTION
* fixed the env to return correct dones, added a test
* copied the baselines' team_helper.py to nmmo/lib, and use it for team spawning (i.e., putting the same team in the same tile)
* when looting items, randomize the item to be processed. Later, we may want to monitor how often the high-level items get discarded and try to minimize wasting high-level items


NOTE: There is another team helper in the task module, as some tasks can benefit from a team helper. We may want to consolidate it into the new team helper.