### PR TITLE
speed up computing action masks

### DIFF
--- a/nmmo/core/config.py
+++ b/nmmo/core/config.py
@@ -145,7 +145,7 @@ class Config(Template):
     return hasattr(self, name)
 
 
-  PROVIDE_ACTION_TARGETS       = False
+  PROVIDE_ACTION_TARGETS       = True
   '''Flag used to provide action targets mask'''
 
   PLAYERS                      = [Agent]

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -144,8 +144,6 @@ class Observation:
     return gym_obs
 
   def _make_action_targets(self):
-    # TODO(kywch): return all-0 masks for buy/sell/give during combat
-
     masks = {}
     masks[action.Move] = {
       action.Direction: self._make_move_mask()

--- a/scripted/move.py
+++ b/scripted/move.py
@@ -45,13 +45,13 @@ def pathfind(config, ob, actions, rr, cc):
 
 def meander(config, ob, actions):
    cands = []
-   if ob.tile(-1, 0).material_id in material.Habitable:
+   if ob.tile(-1, 0).material_id in material.Habitable.indices:
       cands.append((-1, 0))
-   if ob.tile(1, 0).material_id in material.Habitable:
+   if ob.tile(1, 0).material_id in material.Habitable.indices:
       cands.append((1, 0))
-   if ob.tile(0, -1).material_id in material.Habitable:
+   if ob.tile(0, -1).material_id in material.Habitable.indices:
       cands.append((0, -1))
-   if ob.tile(0, 1).material_id in material.Habitable:
+   if ob.tile(0, 1).material_id in material.Habitable.indices:
       cands.append((0, 1))
    if not cands:
       return (-1, 0)
@@ -112,7 +112,7 @@ def forageDijkstra(config, ob: Observation, actions, food_max, water_max, cutoff
          tile     = ob.tile(*nxt)
          matl     = tile.material_id
 
-         if not matl in material.Habitable:
+         if not matl in material.Habitable.indices:
             continue
 
          food, water = reward[cur]
@@ -211,7 +211,7 @@ def gatherBFS(config, ob: Observation, actions, resource, cutoff=100):
                 backtrace[nxt] = cur
                 break
 
-            if not tile.material_id in material.Habitable:
+            if not tile.material_id in material.Habitable.indices:
                 continue
 
             if matl in (e.index for e in resource):
@@ -285,11 +285,11 @@ def aStar(config, ob: Observation, actions, rr, cc, cutoff=100):
          tile     = ob.tile(*nxt)
          matl     = tile.material_id
 
-         if not matl in material.Habitable:
+         if not matl in material.Habitable.indices:
            continue
 
          #Omitted water from the original implementation. Seems key
-         if matl in material.Impassible:
+         if matl in material.Impassible.indices:
             continue
 
          newCost = cost[cur] + 1

--- a/tests/core/test_action_target.py
+++ b/tests/core/test_action_target.py
@@ -9,6 +9,8 @@ from nmmo.core.observation import Observation
 from nmmo.core import action as Action
 from nmmo.lib import material as Material
 
+TileAttr = TileState.State.attr_name_to_col
+
 class TestActionTargets(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
@@ -19,8 +21,7 @@ class TestActionTargets(unittest.TestCase):
       cls.env.step({})
 
   def test_tile_attr(self):
-    self.assertDictEqual(TileState.State.attr_name_to_col,
-                         {'row': 0, 'col': 1, 'material_id': 2})
+    self.assertDictEqual(TileAttr, {'row': 0, 'col': 1, 'material_id': 2})
 
   def test_move_mask_correctness(self):
     obs = self.env._compute_observations()
@@ -35,12 +36,12 @@ class TestActionTargets(unittest.TestCase):
 
     for agent_obs in obs.values():
       # check if the coord conversion is correct
-      x_map = agent_obs.tiles[:,0].reshape(tile_dim,tile_dim)
-      y_map = agent_obs.tiles[:,1].reshape(tile_dim,tile_dim)
-      mat_map = agent_obs.tiles[:,2].reshape(tile_dim,tile_dim)
+      row_map = agent_obs.tiles[:,TileAttr['row']].reshape(tile_dim,tile_dim)
+      col_map = agent_obs.tiles[:,TileAttr['col']].reshape(tile_dim,tile_dim)
+      mat_map = agent_obs.tiles[:,TileAttr['material_id']].reshape(tile_dim,tile_dim)
       agent = agent_obs.agent()
-      self.assertEqual(agent.row, x_map[center,center])
-      self.assertEqual(agent.col, y_map[center,center])
+      self.assertEqual(agent.row, row_map[center,center])
+      self.assertEqual(agent.col, col_map[center,center])
       self.assertEqual(agent_obs.tile(0,0).material_id, mat_map[center,center])
 
       mask_ref = correct_move_mask(agent_obs)

--- a/tests/core/test_action_target.py
+++ b/tests/core/test_action_target.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
   # test_func = [
   #   '_make_move_mask()', # 0.170 -> 0.022
   #   '_make_attack_mask()', # 0.060 -> 0.037
-  #   '_make_use_mask()',
+  #   '_make_use_mask()', # 0.0036 ->
   #   '_make_sell_mask()',
   #   '_make_give_target_mask()',
   #   '_make_destroy_item_mask()',
@@ -80,3 +80,8 @@ if __name__ == '__main__':
 
   # for func in test_func:
   #   print(func, timeit(f'obs[1].{func}', number=1000, globals=globals()))
+
+  # # without ActionTargets: 0.97 (before) -> 0.26 (after)
+  # # with ActionTargets: 3.23 (before) -> 2.45 (after)
+  # print('obs._to_gym()', timeit(lambda: {a: o.to_gym() for a,o in obs.items()},
+  #                               number=100, globals=globals()))

--- a/tests/core/test_action_target.py
+++ b/tests/core/test_action_target.py
@@ -1,0 +1,81 @@
+# pylint: disable=protected-access,bad-builtin
+import unittest
+from timeit import timeit
+import numpy as np
+
+import nmmo
+from nmmo.core.tile import TileState
+from nmmo.core.observation import Observation
+from nmmo.core import action as Action
+from nmmo.lib import material as Material
+
+class TestActionTargets(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.config = nmmo.config.Default()
+    cls.env = nmmo.Env(cls.config)
+    cls.env.reset()
+    for _ in range(3):
+      cls.env.step({})
+
+  def test_tile_attr(self):
+    self.assertDictEqual(TileState.State.attr_name_to_col,
+                         {'row': 0, 'col': 1, 'material_id': 2})
+
+  def test_move_mask_correctness(self):
+    obs = self.env._compute_observations()
+
+    center = self.config.PLAYER_VISION_RADIUS
+    tile_dim = self.config.PLAYER_VISION_DIAMETER
+
+    def correct_move_mask(agent_obs: Observation):
+      # pylint: disable=not-an-iterable
+      return np.array([agent_obs.tile(*d.delta).material_id in Material.Habitable
+                       for d in Action.Direction.edges], dtype=np.int8)
+
+    for agent_obs in obs.values():
+      # check if the coord conversion is correct
+      x_map = agent_obs.tiles[:,0].reshape(tile_dim,tile_dim)
+      y_map = agent_obs.tiles[:,1].reshape(tile_dim,tile_dim)
+      mat_map = agent_obs.tiles[:,2].reshape(tile_dim,tile_dim)
+      agent = agent_obs.agent()
+      self.assertEqual(agent.row, x_map[center,center])
+      self.assertEqual(agent.col, y_map[center,center])
+      self.assertEqual(agent_obs.tile(0,0).material_id, mat_map[center,center])
+
+      mask_ref = correct_move_mask(agent_obs)
+      self.assertTrue(np.array_equal(agent_obs._make_move_mask(), mask_ref))
+
+    # pylint: disable=unnecessary-lambda
+    print('reference:', timeit(lambda: correct_move_mask(agent_obs),
+                               number=1000, globals=globals()))
+    print('implemented:', timeit(lambda: agent_obs._make_move_mask(),
+                                 number=1000, globals=globals()))
+
+if __name__ == '__main__':
+  unittest.main()
+
+  # config = nmmo.config.Default()
+  # env = nmmo.Env(config)
+  # env.reset()
+  # for _ in range(10):
+  #   env.step({})
+
+  # obs = env._compute_observations()
+
+  # test_func = [
+  #   '_make_move_mask()', # 0.170 -> 0.022
+  #   '_make_attack_mask()', # 0.060 -> 0.037
+  #   '_make_use_mask()',
+  #   '_make_sell_mask()',
+  #   '_make_give_target_mask()',
+  #   '_make_destroy_item_mask()',
+  #   '_make_buy_mask()', # 0.022 -> 0.011
+  #   '_make_give_gold_mask()',
+  #   '_existing_ammo_listings()',
+  #   'agent()',
+  #   'tile(1,-1)' # 0.020 (cache off) -> 0.012
+  # ]
+
+  # for func in test_func:
+  #   print(func, timeit(f'obs[1].{func}', number=1000, globals=globals()))

--- a/tests/task/test_predicates.py
+++ b/tests/task/test_predicates.py
@@ -153,18 +153,19 @@ class TestBasePredicate(unittest.TestCase):
     env = self._get_taskenv(test_tasks, grass_map=True)
 
     # Two corners to the target materials
-    MS = env.config.MAP_SIZE
-    tile = env.realm.map.tiles[0,MS-2]
+    BORDER = env.config.MAP_BORDER
+    MS = env.config.MAP_CENTER + BORDER
+    tile = env.realm.map.tiles[BORDER,MS-2]
     tile.material = Material.Foilage
     tile.material_id.update(Material.Foilage.index)
 
-    tile = env.realm.map.tiles[MS-1,0]
+    tile = env.realm.map.tiles[MS-1,BORDER]
     tile.material = Material.Water
     tile.material_id.update(Material.Water.index)
 
     # All agents to one corner
     for ent_id in env.realm.players:
-      change_agent_pos(env.realm,ent_id,(0,0))
+      change_agent_pos(env.realm,ent_id,(BORDER,BORDER))
 
     env.obs = env._compute_observations()
     _, _, _, infos = env.step({})
@@ -174,8 +175,8 @@ class TestBasePredicate(unittest.TestCase):
     self._check_result(env, test_tasks, infos, true_task)
 
     # Team one to foilage, team two to water
-    change_agent_pos(env.realm,1,(0,MS-2)) # agent 1, team 0, foilage
-    change_agent_pos(env.realm,2,(MS-2,0)) # agent 2, team 1, water
+    change_agent_pos(env.realm,1,(BORDER,MS-2)) # agent 1, team 0, foilage
+    change_agent_pos(env.realm,2,(MS-2,BORDER)) # agent 2, team 1, water
     env.obs = env._compute_observations()
 
     _, _, _, infos = env.step({})
@@ -197,11 +198,12 @@ class TestBasePredicate(unittest.TestCase):
     env = self._get_taskenv(test_tasks, grass_map=True)
 
     # All agents to one corner
+    BORDER = env.config.MAP_BORDER
+    MS = env.config.MAP_CENTER + BORDER
     for ent_id in env.realm.players:
-      change_agent_pos(env.realm,ent_id,(0,0))
+      change_agent_pos(env.realm,ent_id,(BORDER,BORDER)) # the map border
 
     # Teleport agent 1 to the opposite corner
-    MS = env.config.MAP_SIZE
     change_agent_pos(env.realm,1,(MS-2,MS-2))
     env.obs = env._compute_observations()
 


### PR DESCRIPTION
These mask functions in `observation.py` were optimized (based on timeit 1000 iter)
* _make_move_mask(): 0.170 -> 0.022
* _make_attack_mask(): 0.060 -> 0.037
* _make_buy_mask(): 0.022 -> 0.011

Observation.tile() was expensive, so _make_move_mask directly access the tile map by computing the indices, and the tests were added to make sure the coordinates are correct. Also, expensive np.concatenate and redundant operations were removed from attack/buy masks.

Observation.tile() was also changed to compute indices directly and "parse array" internally.
