### PR TITLE
made env._compute_observations() faster

### DIFF
--- a/nmmo/core/tile.py
+++ b/nmmo/core/tile.py
@@ -4,7 +4,7 @@ import numpy as np
 from nmmo.datastore.serialized import SerializedState
 from nmmo.lib import material
 
-# pylint: disable=no-member
+# pylint: disable=no-member,protected-access
 TileState = SerializedState.subclass(
   "Tile", [
     "row",
@@ -23,6 +23,9 @@ TileState.Query = SimpleNamespace(
     TileState.State.attr_name_to_col["row"],
     TileState.State.attr_name_to_col["col"],
     r, c, radius),
+  get_map=lambda ds, map_size:
+    ds.table("Tile")._data[1:(map_size*map_size+1)]
+                    .reshape((map_size,map_size,len(TileState.State.attr_name_to_col)))
 )
 
 class Tile(TileState):

--- a/tests/task/test_predicates.py
+++ b/tests/task/test_predicates.py
@@ -251,8 +251,9 @@ class TestBasePredicate(unittest.TestCase):
     env = self._get_taskenv(test_preds, grass_map=True)
 
     # All agents to one corner
+    BORDER = env.config.MAP_BORDER
     for ent_id in env.realm.players:
-      change_agent_pos(env.realm,ent_id,(0,0))
+      change_agent_pos(env.realm,ent_id,(BORDER,BORDER))
     env.obs = env._compute_observations()
 
     _, _, _, infos = env.step({})


### PR DESCRIPTION
replaced the expensive tile window query (on row and col) with the index look up. 

 - tile map window query: 0.1153785250025976 s per 1000 calls
 - look up by index: 0.004833787003008183 s per 1000 calls
 - A test was added to check these outputs match: `tests/core/test_observation_tile.py`

so, `env._compute_observations()` got much faster, from 2.03 s -> 0.65 s per 100 calls

before: (WSL, the default task)
 - env.step({}): 7.819248097999662
 - env.realm.step(): 1.601971907002735
 - env._compute_observations(): 2.038284816997475
 - obs.to_gym(), ActionTarget: 1.49435229300434
 - env._compute_rewards(): 1.6132002679951256

after:
 - env.step({}): 6.491634746002092
 - env.realm.step(): 1.611555720002798
 **- env._compute_observations(): 0.647985998999502**
 - obs.to_gym(), ActionTarget: 1.5792435760013177
 - env._compute_rewards(): 1.5641796529998828

