### PR TITLE
made obs, make_attack_mask faster

### DIFF
--- a/nmmo/lib/utils.py
+++ b/nmmo/lib/utils.py
@@ -72,7 +72,7 @@ def seed():
 def linf(pos1, pos2):
   # pos could be a single (r,c) or a vector of (r,c)s
   diff = np.abs(np.array(pos1) - np.array(pos2))
-  return np.max(diff, axis=len(diff.shape)-1)
+  return np.max(diff, axis=-1)
 
 #Bounds checker
 def in_bounds(r, c, shape, border=0):


### PR DESCRIPTION
further optimized observations (np array-related), made make_attack_mask faster

previous within_attack_range: 0.014650394001364475 per 1000 calls
new implementation: 0.005642822998197516 per 1000 calls

A test was added to check these outputs match: tests/core/test_observation_tile.py

before: (WSL, the default task, from the PR #81)

- env.step({}): 6.491634746002092
- env.realm.step(): 1.611555720002798
- env._compute_observations(): 0.647985998999502
- obs.to_gym(), ActionTarget: 1.5792435760013177
- env._compute_rewards(): 1.5641796529998828

after:
 - env.step({}): 6.366554959000496
 - env.realm.step(): 1.7872028359997785
 - env._compute_observations(): 0.6816526229995361
 - obs.to_gym(), ActionTarget: 1.1643277820003277 <-- HERE
 - env._compute_rewards(): 1.6867663449993415
