### PR TITLE
made compute_reward faster

### DIFF
--- a/nmmo/lib/utils.py
+++ b/nmmo/lib/utils.py
@@ -72,7 +72,7 @@ def seed():
 def linf(pos1, pos2):
   # pos could be a single (r,c) or a vector of (r,c)s
   diff = np.abs(np.array(pos1) - np.array(pos2))
-  return np.max(diff, axis=len(diff.shape)-1)
+  return np.max(diff, axis=-1)
 
 #Bounds checker
 def in_bounds(r, c, shape, border=0):


### PR DESCRIPTION
this PR is built on PR #82, but the main changes are related to game_state's `where_in_1d()`, which scans the whole numpy tables. 

* lazy evaluation of GroupView data "attributes", which calls `where_in_1d()`
* made GameState.where_in_1d() faster with the pre-computed indices
```
---test_gs_where_in_1d---
reference: 0.013866528002836276    per 1000 calls
implemented: 0.008685622000484727
```
* added caching inside `where_in_1d()`, just in case

before: (WSL, the default task, from the PR #81)
- env.step({}): 6.491634746002092
- env.realm.step(): 1.611555720002798
- env._compute_observations(): 0.647985998999502
- obs.to_gym(), ActionTarget: 1.5792435760013177
- env._compute_rewards(): 1.5641796529998828

after: + PR #82 + this one
 - env.step({}): 5.485962980994373
 - env.realm.step(): 1.818406842998229
 - env._compute_observations(): 0.6747147139976732
 - obs.to_gym(), ActionTarget: 1.2018060390037135  <-- PR #82 
 - env._compute_rewards(): 0.8694456899975194 <-- THIS PR
