### PR TITLE
Check if obs matches the obs space

### DIFF
--- a/nmmo/core/env.py
+++ b/nmmo/core/env.py
@@ -412,7 +412,7 @@ class Env(ParallelEnv):
     market = Item.Query.for_sale(self.realm.datastore)
 
     # get tile map, to bypass the expensive tile window query
-    tile_map = Tile.Query.get_map(self.realm.datastore, self.config.MAP_SIZE).astype(np.int16)
+    tile_map = Tile.Query.get_map(self.realm.datastore, self.config.MAP_SIZE)
     radius = self.config.PLAYER_VISION_RADIUS
     tile_obs_size = ((2*radius+1)**2, len(Tile.State.attr_name_to_col))
 

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -1,4 +1,4 @@
-from functools import lru_cache
+from functools import lru_cache, cached_property
 
 import numpy as np
 
@@ -15,7 +15,7 @@ class BasicObs:
     self.values = values
     self.ids = values[:, id_col]
 
-  @property
+  @cached_property
   def len(self):
     return len(self.ids)
 
@@ -104,7 +104,7 @@ class Observation:
   @lru_cache(maxsize=None)
   def entity(self, entity_id):
     rows = self.entities.values[self.entities.ids == entity_id]
-    if rows.size == 0:
+    if rows.shape[0] == 0:
       return None
     return EntityState.parse_array(rows[0])
 
@@ -257,8 +257,8 @@ class Observation:
     # level limits are differently applied depending on item types
     type_flt = np.tile(np.array(list(item_skill.keys())), (self.inventory.len,1))
     level_flt = np.tile(np.array(list(item_skill.values())), (self.inventory.len,1))
-    item_type = np.tile(np.transpose(np.atleast_2d(item_type)), (1, len(item_skill)))
-    item_level = np.tile(np.transpose(np.atleast_2d(item_level)), (1, len(item_skill)))
+    item_type = np.tile(np.transpose(np.atleast_2d(item_type)), (1,len(item_skill)))
+    item_level = np.tile(np.transpose(np.atleast_2d(item_level)), (1,len(item_skill)))
     level_satisfied = np.any((item_type==type_flt) & (item_level<=level_flt), axis=1)
 
     use_mask[:self.inventory.len] = not_listed & level_satisfied

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -115,14 +115,14 @@ class Observation:
 
   def get_empty_obs(self):
     gym_obs = {
-      "CurrentTick": np.array([self.current_tick]),
-      "AgentId": np.array([self.agent_id]),
+      "CurrentTick": self.current_tick,
+      "AgentId": self.agent_id,
       "Tile": None, # np.zeros((self.config.MAP_N_OBS, self.tiles.shape[1])),
       "Entity": np.zeros((self.config.PLAYER_N_OBS,
                           self.entities.values.shape[1]), dtype=np.int16)}
     if self.config.ITEM_SYSTEM_ENABLED:
       gym_obs["Inventory"] = np.zeros((self.config.INVENTORY_N_OBS,
-                                       self.inventory.values.shape[1]))
+                                       self.inventory.values.shape[1]), dtype=np.int16)
     if self.config.EXCHANGE_SYSTEM_ENABLED:
       gym_obs["Market"] = np.zeros((self.config.MARKET_N_OBS,
                                     self.market.values.shape[1]), dtype=np.int16)

--- a/nmmo/datastore/numpy_datastore.py
+++ b/nmmo/datastore/numpy_datastore.py
@@ -6,7 +6,7 @@ from nmmo.datastore.datastore import Datastore, DataTable
 
 
 class NumpyTable(DataTable):
-  def __init__(self, num_columns: int, initial_size: int, dtype=np.float32):
+  def __init__(self, num_columns: int, initial_size: int, dtype=np.int16):
     super().__init__(num_columns)
     self._dtype  = dtype
     self._initial_size = initial_size

--- a/nmmo/task/game_state.py
+++ b/nmmo/task/game_state.py
@@ -221,11 +221,11 @@ class GameStateGenerator:
 
   def generate(self, realm: Realm, env_obs: Dict[int, Observation]) -> GameState:
     # copy the datastore, by running astype
-    entity_all = EntityState.Query.table(realm.datastore).astype(np.int16)
+    entity_all = EntityState.Query.table(realm.datastore).copy()
     alive_agents = entity_all[:, EntityAttr["id"]]
     alive_agents = set(alive_agents[alive_agents > 0])
-    item_data = ItemState.Query.table(realm.datastore).astype(np.int16)
-    event_data = EventState.Query.table(realm.datastore).astype(np.int16)
+    item_data = ItemState.Query.table(realm.datastore).copy()
+    event_data = EventState.Query.table(realm.datastore).copy()
 
     return GameState(
       current_tick = realm.tick,

--- a/tests/core/test_env.py
+++ b/tests/core/test_env.py
@@ -87,7 +87,7 @@ class TestEnv(unittest.TestCase):
           dead_agents.add(dead_id)
 
       # check dead and alive
-      entity_all = EntityState.Query.table(self.env.realm.datastore).astype(np.int16)
+      entity_all = EntityState.Query.table(self.env.realm.datastore)
       alive_agents = entity_all[:, Entity.State.attr_name_to_col["id"]]
       alive_agents = set(alive_agents[alive_agents > 0])
       for agent_id in alive_agents:

--- a/tests/core/test_gym_obs_spaces.py
+++ b/tests/core/test_gym_obs_spaces.py
@@ -2,7 +2,7 @@ import unittest
 
 import nmmo
 
-class TestGymSpaces(unittest.TestCase):
+class TestGymObsSpaces(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     cls.config = nmmo.config.Default()
@@ -11,7 +11,7 @@ class TestGymSpaces(unittest.TestCase):
     for _ in range(3):
       cls.env.step({})
 
-  def test_obs_space(self):
+  def test_gym_obs_space(self):
     obs_spec = self.env.observation_space(1)
     obs, _, _, _ = self.env.step({})
 

--- a/tests/core/test_gym_spaces.py
+++ b/tests/core/test_gym_spaces.py
@@ -1,0 +1,34 @@
+import unittest
+
+import nmmo
+
+class TestGymSpaces(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.config = nmmo.config.Default()
+    cls.env = nmmo.Env(cls.config)
+    cls.env.reset(seed=1)
+    for _ in range(3):
+      cls.env.step({})
+
+  def test_obs_space(self):
+    obs_spec = self.env.observation_space(1)
+    obs, _, _, _ = self.env.step({})
+
+    for agent_obs in obs.values():
+      for key, val in agent_obs.items():
+        if key != 'ActionTargets':
+          self.assertTrue(obs_spec[key].contains(val),
+                          f"Invalid obs format -- key: {key}, val: {val}")
+
+      if 'ActionTargets' in agent_obs:
+        val = agent_obs['ActionTargets']
+        for atn in nmmo.Action.edges(self.config):
+          if atn.enabled(self.config):
+            for arg in atn.edges: # pylint: disable=not-an-iterable
+              self.assertTrue(obs_spec['ActionTargets'][atn][arg].contains(val[atn][arg]),
+                              f"Invalid obs format -- key: {atn}/{arg}, val: {val[atn][arg]}")
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/core/test_observation_tile.py
+++ b/tests/core/test_observation_tile.py
@@ -153,7 +153,7 @@ class TestObservationTile(unittest.TestCase):
       flt_idx = [row for sbj in subject for row in index.get(sbj,[])]
       return event_data[flt_idx]
 
-    event_data = EventState.Query.table(env.realm.datastore).astype(np.int16)
+    event_data = EventState.Query.table(env.realm.datastore)
     event_index = defaultdict()
     for row, id_ in enumerate(event_data[:,EventAttr['ent_id']]):
       if id_ in event_index:
@@ -163,10 +163,13 @@ class TestObservationTile(unittest.TestCase):
 
     # NOTE: the index-based approach returns the data in different order,
     #   and all the operations in the task system don't use the order info
-    arr = where_in_1d_with_index(event_data, [1,2,3], event_index)
-    sorted_idx = np.argsort(arr[:,0]) # event_id
-    self.assertTrue(np.array_equal(correct_where_in_1d(event_data, [1,2,3]),
-                                   arr[sorted_idx]))
+    def sort_event_data(event_data):
+      keys = [event_data[:,i] for i in range(1,8)]
+      sorted_idx = np.lexsort(keys)
+      return event_data[sorted_idx]
+    arr1 = sort_event_data(correct_where_in_1d(event_data, [1,2,3]))
+    arr2 = sort_event_data(where_in_1d_with_index(event_data, [1,2,3], event_index))
+    self.assertTrue(np.array_equal(arr1, arr2))
 
     print('---test_gs_where_in_1d---')
     print('reference:', timeit(

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -78,21 +78,21 @@ class TestEventLog(unittest.TestCase):
     log_data = [list(row) for row in event_log.get_data()]
 
     self.assertListEqual(log_data, [
-      [ 1,  1, 1, EventCode.EAT_FOOD, 0, 0, 0, 0, 0],
-      [ 2,  2, 1, EventCode.DRINK_WATER, 0, 0, 0, 0, 0],
-      [ 3,  2, 1, EventCode.SCORE_HIT, 1, 0, 50, 0, 0],
-      [ 4,  3, 1, EventCode.PLAYER_KILL, 0, 5, 0, 0, 5],
-      [ 5,  4, 2, EventCode.CONSUME_ITEM, 16, 8, 1, 0, 0],
-      [ 6,  4, 2, EventCode.GIVE_ITEM, 0, 0, 0, 0, 0],
-      [ 7,  5, 2, EventCode.DESTROY_ITEM, 0, 0, 0, 0, 0],
-      [ 8,  6, 2, EventCode.HARVEST_ITEM, 13, 3, 1, 0, 0],
-      [ 9,  7, 3, EventCode.GIVE_GOLD, 0, 0, 0, 0, 0],
-      [10,  8, 3, EventCode.LIST_ITEM, 16, 5, 1, 11, 0],
-      [11,  9, 3, EventCode.EARN_GOLD, 0, 0, 0, 15, 0],
-      [12, 10, 3, EventCode.BUY_ITEM, 13, 7, 1, 21, 0],
-      [13, 12, 4, EventCode.LEVEL_UP, 4, 3, 0, 0, 0],
-      [14, 12, 5, EventCode.GO_FARTHEST, 0, 0, 6, 0, 0],
-      [15, 12, 5, EventCode.EQUIP_ITEM, 2, 4, 1, 0, 0]])
+      [1,  1, 1, EventCode.EAT_FOOD, 0, 0, 0, 0, 0],
+      [1,  2, 1, EventCode.DRINK_WATER, 0, 0, 0, 0, 0],
+      [1,  2, 1, EventCode.SCORE_HIT, 1, 0, 50, 0, 0],
+      [1,  3, 1, EventCode.PLAYER_KILL, 0, 5, 0, 0, 5],
+      [1,  4, 2, EventCode.CONSUME_ITEM, 16, 8, 1, 0, 0],
+      [1,  4, 2, EventCode.GIVE_ITEM, 0, 0, 0, 0, 0],
+      [1,  5, 2, EventCode.DESTROY_ITEM, 0, 0, 0, 0, 0],
+      [1,  6, 2, EventCode.HARVEST_ITEM, 13, 3, 1, 0, 0],
+      [1,  7, 3, EventCode.GIVE_GOLD, 0, 0, 0, 0, 0],
+      [1,  8, 3, EventCode.LIST_ITEM, 16, 5, 1, 11, 0],
+      [1,  9, 3, EventCode.EARN_GOLD, 0, 0, 0, 15, 0],
+      [1, 10, 3, EventCode.BUY_ITEM, 13, 7, 1, 21, 0],
+      [1, 12, 4, EventCode.LEVEL_UP, 4, 3, 0, 0, 0],
+      [1, 12, 5, EventCode.GO_FARTHEST, 0, 0, 6, 0, 0],
+      [1, 12, 5, EventCode.EQUIP_ITEM, 2, 4, 1, 0, 0]])
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/testhelpers.py
+++ b/tests/testhelpers.py
@@ -383,7 +383,7 @@ def profile_env_step(action_target=True, tasks=None, condition=None):
   config.PLAYERS = [baselines.Sleeper] # the scripted agents doing nothing
   config.IMMORTAL = True # otherwise the agents will die
   config.PROVIDE_ACTION_TARGETS = action_target
-  env = nmmo.Env(config)
+  env = nmmo.Env(config, seed=0)
   if tasks is None:
     tasks = []
   env.reset(seed=0, make_task_fn=lambda: tasks)


### PR DESCRIPTION

NOTE: this PR is built on PR #84, the `realm-rng`

* `env.observation_space()` returns the correct gym spaces, including the ActionTargets
* A test was added to ensure the obs output matches observation_spaces()
* The data tables' dtype was changed to int16, and unnecessary type conversions were all removed
* Since the event table is write-only, row id is not necessary, although it could go over int16 limit if the game is big and long. So, the unique row id was replaced with a recorded flag.  
