### PR TITLE
Added no actions

### DIFF
--- a/nmmo/core/action.py
+++ b/nmmo/core/action.py
@@ -50,9 +50,6 @@ class Node(metaclass=utils.IterableNameComparable):
   def deserialize(realm, entity, index):
     return index
 
-  def args(stim, entity, config):
-    return []
-
 class Fixed:
   pass
 
@@ -76,7 +73,7 @@ class Action(Node):
     arguments = []
     for action in Action.edges(config):
       action.init(config)
-      for args in action.edges:
+      for args in action.edges: # pylint: disable=not-an-iterable
         args.init(config)
         if not 'edges' in args.__dict__:
           continue
@@ -105,9 +102,6 @@ class Action(Node):
     if config.COMMUNICATION_SYSTEM_ENABLED:
       edges.append(Comm)
     return edges
-
-  def args(stim, entity, config):
-    raise NotImplementedError
 
 class Move(Node):
   priority = 60
@@ -168,9 +162,6 @@ class Direction(Node):
   @staticproperty
   def edges():
     return [North, South, East, West, Stay]
-
-  def args(stim, entity, config):
-    return Direction.edges
 
   def deserialize(realm, entity, index):
     return deserialize_fixed_arg(Direction, index)
@@ -284,9 +275,6 @@ class Style(Node):
   def edges():
     return [Melee, Range, Mage]
 
-  def args(stim, entity, config):
-    return Style.edges
-
   def deserialize(realm, entity, index):
     return deserialize_fixed_arg(Style, index)
 
@@ -313,10 +301,6 @@ class Target(Node):
 
     entity_id = entity_obs[index, Entity.State.attr_name_to_col["id"]]
     return realm.entity_or_none(entity_id)
-
-  def args(stim, entity, config):
-    #Should pass max range?
-    return Attack.in_range(entity, stim, config, None)
 
 class Melee(Node):
   nodeType = NodeType.ACTION
@@ -354,9 +338,6 @@ class InventoryItem(Node):
   @classmethod
   def N(cls, config):
     return config.INVENTORY_N_OBS + 1 # +1 for the "None" item
-
-  def args(stim, entity, config):
-    return stim.exchange.items()
 
   def deserialize(realm, entity, index: int):
     # NOTE: index is from the inventory, NOT item id
@@ -547,9 +528,6 @@ class MarketItem(Node):
   def N(cls, config):
     return config.MARKET_N_OBS + 1 # +1 for the "None" item
 
-  def args(stim, entity, config):
-    return stim.exchange.items()
-
   def deserialize(realm, entity, index: int):
     # NOTE: index is from the market, NOT item id
     if index >= realm.config.MARKET_N_OBS or index < 0: # checking for the "None" item
@@ -668,9 +646,6 @@ class Price(Node):
   def edges():
     return Price.classes
 
-  def args(stim, entity, config):
-    return Price.edges
-
   def deserialize(realm, entity, index):
     return deserialize_fixed_arg(Price, index)
 
@@ -684,9 +659,6 @@ class Token(Node):
   @staticproperty
   def edges():
     return Token.classes
-
-  def args(stim, entity, config):
-    return Token.edges
 
   def deserialize(realm, entity, index):
     return deserialize_fixed_arg(Token, index)

--- a/nmmo/core/action.py
+++ b/nmmo/core/action.py
@@ -7,7 +7,9 @@ import numpy as np
 from nmmo.lib import utils
 from nmmo.lib.utils import staticproperty
 from nmmo.systems.item import Item, Stack
+from nmmo.entity.entity import Entity
 from nmmo.lib.log import EventCode
+
 
 class NodeType(Enum):
   #Tree edges
@@ -304,12 +306,25 @@ class Target(Node):
 
   @classmethod
   def N(cls, config):
-    return config.PLAYER_N_OBS
+    return config.PLAYER_N_OBS + 1 # +1 for the "None" target
 
   def deserialize(realm, entity, index: int):
-    # NOTE: index is the entity id
-    # CHECK ME: should index be renamed to ent_id?
-    return realm.entity_or_none(index)
+    # NOTE: index is from the entity obs, NOT the entity id
+    if index >= realm.config.PLAYER_N_OBS or index < 0: # checking for the "None" target
+      return None
+
+    radius = realm.config.PLAYER_VISION_RADIUS
+    entity_obs = Entity.Query.window(
+        realm.datastore,
+        entity.row.val, entity.col.val,
+        radius
+    )
+
+    if index >= entity_obs.shape[0]:
+      return None
+
+    entity_id = entity_obs[index, Entity.State.attr_name_to_col["id"]]
+    return realm.entity_or_none(entity_id)
 
   def args(stim, entity, config):
     #Should pass max range?
@@ -351,7 +366,7 @@ class InventoryItem(Node):
 
   @classmethod
   def N(cls, config):
-    return config.INVENTORY_N_OBS
+    return config.INVENTORY_N_OBS + 1 # +1 for the "None" item
 
   # TODO(kywch): What does args do?
   def args(stim, entity, config):
@@ -359,6 +374,9 @@ class InventoryItem(Node):
 
   def deserialize(realm, entity, index: int):
     # NOTE: index is from the inventory, NOT item id
+    if index >= realm.config.INVENTORY_N_OBS or index < 0: # checking for the "None" item
+      return None
+
     inventory = Item.Query.owned_by(realm.datastore, entity.id.val)
 
     if index >= inventory.shape[0]:
@@ -543,7 +561,7 @@ class MarketItem(Node):
 
   @classmethod
   def N(cls, config):
-    return config.MARKET_N_OBS
+    return config.MARKET_N_OBS + 1 # +1 for the "None" item
 
   # TODO(kywch): What does args do?
   def args(stim, entity, config):
@@ -551,6 +569,9 @@ class MarketItem(Node):
 
   def deserialize(realm, entity, index: int):
     # NOTE: index is from the market, NOT item id
+    if index >= realm.config.MARKET_N_OBS or index < 0: # checking for the "None" item
+      return None
+
     market = Item.Query.for_sale(realm.datastore)
 
     if index >= market.shape[0]:

--- a/nmmo/core/action.py
+++ b/nmmo/core/action.py
@@ -109,7 +109,6 @@ class Action(Node):
   def args(stim, entity, config):
     raise NotImplementedError
 
-
 class Move(Node):
   priority = 60
   nodeType = NodeType.SELECTION
@@ -204,7 +203,6 @@ class West(Node):
 class Stay(Node):
   delta = (0, 0)
 
-
 class Attack(Node):
   priority = 50
   nodeType = NodeType.SELECTION
@@ -235,14 +233,6 @@ class Attack(Node):
 
     rets = list(rets)
     return rets
-
-  # CHECK ME: do we need l1 distance function?
-  #   systems/ai/utils.py also has various distance functions
-  #   which we may want to clean up
-  # def l1(pos, cent):
-  #   r, c = pos
-  #   r_cent, c_cent = cent
-  #   return abs(r - r_cent) + abs(c - c_cent)
 
   def call(realm, entity, style, target):
     if style is None or target is None:
@@ -300,7 +290,6 @@ class Style(Node):
   def deserialize(realm, entity, index):
     return deserialize_fixed_arg(Style, index)
 
-
 class Target(Node):
   argType = None
 
@@ -313,11 +302,10 @@ class Target(Node):
     if index >= realm.config.PLAYER_N_OBS or index < 0: # checking for the "None" target
       return None
 
-    radius = realm.config.PLAYER_VISION_RADIUS
     entity_obs = Entity.Query.window(
         realm.datastore,
         entity.row.val, entity.col.val,
-        radius
+        realm.config.PLAYER_VISION_RADIUS
     )
 
     if index >= entity_obs.shape[0]:
@@ -360,7 +348,6 @@ class Mage(Node):
   def skill(entity):
     return entity.skills.mage
 
-
 class InventoryItem(Node):
   argType  = None
 
@@ -368,7 +355,6 @@ class InventoryItem(Node):
   def N(cls, config):
     return config.INVENTORY_N_OBS + 1 # +1 for the "None" item
 
-  # TODO(kywch): What does args do?
   def args(stim, entity, config):
     return stim.exchange.items()
 
@@ -507,7 +493,6 @@ class Give(Node):
 
     realm.event_log.record(EventCode.GIVE_ITEM, entity)
 
-
 class GiveGold(Node):
   priority = 30
 
@@ -555,7 +540,6 @@ class GiveGold(Node):
 
     realm.event_log.record(EventCode.GIVE_GOLD, entity)
 
-
 class MarketItem(Node):
   argType  = None
 
@@ -563,7 +547,6 @@ class MarketItem(Node):
   def N(cls, config):
     return config.MARKET_N_OBS + 1 # +1 for the "None" item
 
-  # TODO(kywch): What does args do?
   def args(stim, entity, config):
     return stim.exchange.items()
 
@@ -691,7 +674,6 @@ class Price(Node):
   def deserialize(realm, entity, index):
     return deserialize_fixed_arg(Price, index)
 
-
 class Token(Node):
   argType  = Fixed
 
@@ -708,7 +690,6 @@ class Token(Node):
 
   def deserialize(realm, entity, index):
     return deserialize_fixed_arg(Token, index)
-
 
 class Comm(Node):
   argType  = Fixed

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -220,7 +220,8 @@ class Observation:
     assert self.config.COMBAT_MELEE_REACH == self.config.COMBAT_RANGE_REACH
     assert self.config.COMBAT_MELEE_REACH == self.config.COMBAT_MAGE_REACH
     assert self.config.COMBAT_RANGE_REACH == self.config.COMBAT_MAGE_REACH
-    attack_mask = np.zeros(self.config.PLAYER_N_OBS, dtype=np.int8)
+    attack_mask = np.zeros(self.config.PLAYER_N_OBS + 1, dtype=np.int8) # +1 for No action
+    attack_mask[-1] = 1 # No action
     if self.dummy_obs:
       return attack_mask
 
@@ -246,7 +247,8 @@ class Observation:
 
   def _make_use_mask(self):
     # empty inventory -- nothing to use
-    use_mask = np.zeros(self.config.INVENTORY_N_OBS, dtype=np.int8)
+    use_mask = np.zeros(self.config.INVENTORY_N_OBS + 1, dtype=np.int8) # +1 for No action
+    use_mask[-1] = 1 # No action
     if not (self.config.ITEM_SYSTEM_ENABLED and self.inventory.len > 0)\
         or self.dummy_obs or self.agent_in_combat:
       return use_mask
@@ -294,7 +296,8 @@ class Observation:
     }
 
   def _make_destroy_item_mask(self):
-    destroy_mask = np.zeros(self.config.INVENTORY_N_OBS, dtype=np.int8)
+    destroy_mask = np.zeros(self.config.INVENTORY_N_OBS + 1, dtype=np.int8) # +1 for No action
+    destroy_mask[-1] = 1 # No action
     # empty inventory -- nothing to destroy
     if not (self.config.ITEM_SYSTEM_ENABLED and self.inventory.len > 0)\
         or self.dummy_obs or self.agent_in_combat:
@@ -307,7 +310,8 @@ class Observation:
     return destroy_mask
 
   def _make_give_target_mask(self):
-    give_mask = np.zeros(self.config.PLAYER_N_OBS, dtype=np.int8)
+    give_mask = np.zeros(self.config.PLAYER_N_OBS + 1, dtype=np.int8) # +1 for No action
+    give_mask[-1] = 1 # No action
     # empty inventory -- nothing to give
     if not (self.config.ITEM_SYSTEM_ENABLED and self.inventory.len > 0)\
         or self.dummy_obs or self.agent_in_combat:
@@ -335,7 +339,8 @@ class Observation:
     return mask
 
   def _make_sell_mask(self):
-    sell_mask = np.zeros(self.config.INVENTORY_N_OBS, dtype=np.int8)
+    sell_mask = np.zeros(self.config.INVENTORY_N_OBS + 1, dtype=np.int8) # +1 for No action
+    sell_mask[-1] = 1 # No action
     # empty inventory -- nothing to sell
     if not (self.config.EXCHANGE_SYSTEM_ENABLED and self.inventory.len > 0) \
       or self.dummy_obs or self.agent_in_combat:
@@ -348,7 +353,8 @@ class Observation:
     return sell_mask
 
   def _make_buy_mask(self):
-    buy_mask = np.zeros(self.config.MARKET_N_OBS, dtype=np.int8)
+    buy_mask = np.zeros(self.config.MARKET_N_OBS + 1, dtype=np.int8) # +1 for No action
+    buy_mask[-1] = 1 # No action
     if not self.config.EXCHANGE_SYSTEM_ENABLED or self.dummy_obs or self.agent_in_combat:
       return buy_mask
 

--- a/scripted/baselines.py
+++ b/scripted/baselines.py
@@ -2,8 +2,8 @@
 # pylint: disable=all
 
 from typing import Dict
-
 from collections import defaultdict
+import numpy as np
 
 import nmmo
 from nmmo import material
@@ -105,11 +105,11 @@ class Scripted(nmmo.Agent):
 
     self.closestID = None
     if self.closest is not None:
-      self.closestID = self.closest.id
+      self.closestID = self.ob.entities.index(self.closest.id)
 
     self.attackerID = None
     if self.attacker is not None:
-      self.attackerID = self.attacker.id
+      self.attackerID = self.ob.entities.index(self.attacker.id)
 
     self.target     = None
     self.targetID   = None

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -29,7 +29,8 @@ class TestAmmoUse(ScriptedTestTemplate):
           + np.sum(gym_obs['ActionTargets'][action.Buy][action.MarketItem])
     for atn in [action.Use, action.Give, action.Destroy, action.Sell]:
       mask += np.sum(gym_obs['ActionTargets'][atn][action.InventoryItem])
-    self.assertEqual(mask, 0)
+    # MarketItem and InventoryTarget have no-action flags, which sum up to 5
+    self.assertEqual(mask, 5)
 
   def test_ammo_fire_all(self):
     env = self._setup_env(random_seed=RANDOM_SEED)
@@ -58,7 +59,7 @@ class TestAmmoUse(ScriptedTestTemplate):
     #  NOTE that agents 1 & 3's attack are invalid due to out-of-range
     env.step({ ent_id: { action.Attack:
         { action.Style: env.realm.players[ent_id].agent.style[0],
-          action.Target: (ent_id+1)%3+1 } }
+          action.Target: env.obs[ent_id].entities.index((ent_id+1)%3+1) } }
         for ent_id in self.ammo })
 
     # check combat status: agents 2 (attacker) and 1 (target) are in combat
@@ -87,7 +88,7 @@ class TestAmmoUse(ScriptedTestTemplate):
     #  NOTE that agent 3's attack command is invalid due to out-of-range
     env.step({ ent_id: { action.Attack:
         { action.Style: env.realm.players[ent_id].agent.style[0],
-          action.Target: (ent_id+1)%3+1 } }
+          action.Target: env.obs[ent_id].entities.index((ent_id+1)%3+1) } }
         for ent_id in self.ammo })
 
     # agents 1 and 2's latest_combat_tick should be updated

--- a/tests/testhelpers.py
+++ b/tests/testhelpers.py
@@ -365,11 +365,12 @@ class ScriptedTestTemplate(unittest.TestCase):
       if atn == action.Give:
         actions[ent_id] = { action.Give: {
           action.InventoryItem: env.obs[ent_id].inventory.sig(*cond['item_sig']),
-          action.Target: cond['tgt_id'] } }
+          action.Target: env.obs[ent_id].entities.index(cond['tgt_id']) } }
 
       elif atn == action.GiveGold:
         actions[ent_id] = { action.GiveGold:
-          { action.Target: cond['tgt_id'], action.Price: cond['gold'] } }
+          { action.Target: env.obs[ent_id].entities.index(cond['tgt_id']),
+           action.Price: cond['gold'] } }
 
       elif atn == action.Buy:
         mkt_idx = ent_obs.market.index(cond['item_id'])


### PR DESCRIPTION
* Added no actions to `Target` (used in `Attack`, `Give`, `Give-Gold`), `InventoryItem` (used in `Use`, `Sell`, `Destroy`, `Give`), and `MarketItem` (used in `Buy`) in `action.py`
* Previously, `Target` used the entity_id directly. This was now changed to use the index in the entity obs, as the other actions do. --> Scripted agents were also modified accordingly
* The "no-action" mask was added to `ActionTargets` and set to 1
* `Env._obs_space()` was refactored, simplifying the ActionTarget-related code 