### PR TITLE
support discontinuous team ids

### DIFF
--- a/nmmo/lib/team_helper.py
+++ b/nmmo/lib/team_helper.py
@@ -24,14 +24,20 @@ class TeamHelper():
     return agent_id in self.teams[team_id]
 
   def get_target_agent(self, team_id: int, target: str):
+    team_ids = list(self.teams.keys())
+    idx = team_ids.index(team_id)
     if target == 'left_team':
-      return self.teams[(team_id+1) % self.num_teams]
+      target_id = team_ids[(idx+1) % self.num_teams]
+      return self.teams[target_id]
     if target == 'left_team_leader':
-      return self.teams[(team_id+1) % self.num_teams][0]
+      target_id = team_ids[(idx+1) % self.num_teams]
+      return self.teams[target_id][0]
     if target == 'right_team':
-      return self.teams[(team_id-1) % self.num_teams]
+      target_id = team_ids[(idx-1) % self.num_teams]
+      return self.teams[target_id]
     if target == 'right_team_leader':
-      return self.teams[(team_id-1) % self.num_teams][0]
+      target_id = team_ids[(idx-1) % self.num_teams]
+      return self.teams[target_id][0]
     if target == 'my_team_leader':
       return self.teams[team_id][0]
     return None

--- a/nmmo/task/base_predicates.py
+++ b/nmmo/task/base_predicates.py
@@ -64,6 +64,8 @@ def CanSeeAgent(gs: GameState, subject: Group, target: int):
 def CanSeeGroup(gs: GameState, subject: Group, target: Iterable[int]):
   """ Returns True if subject can see any of target
   """
+  if target is None:
+    return False
   return any(CanSeeAgent(gs, subject, agent) for agent in target)
 
 def DistanceTraveled(gs: GameState, subject: Group, dist: int):

--- a/tests/task/test_demo_task_creation.py
+++ b/tests/task/test_demo_task_creation.py
@@ -213,25 +213,7 @@ class TestDemoTask(unittest.TestCase):
     # DONE
 
   def test_task_spec_based_curriculum(self):
-    """
-    task_spec is a list of tuple (reward_to, evaluation function, eval_fn_kwargs, task_kwargs)
-    each tuple in the task_spec will create tasks for a team in teams
-
-    reward_to: must be in ['team', 'agent']
-      * 'team' create a single team task, in which all team members get rewarded
-      * 'agent' create a task for each agent, in which only the agent gets rewarded
-
-    evaluation functions from the base_predicates.py or could be custom functions like above
-
-    eval_fn_kwargs are the additional args that go into predicate. There are also special keys
-      * 'target' must be ['left_team', 'right_team', 'left_team_leader', 'right_team_leader']
-          these str will be translated into the actual agent ids
-
-    task_kwargs are the optional, additional args that go into the task.
-      * 'task_cls' specifies the task class to be used. 
-         If not provided, the standard Task is used.
-    """
-    task_spec = [ # (reward_to, predicate function, kwargs)
+    task_spec = [
       ts.TaskSpec(eval_fn=bp.CountEvent, eval_fn_kwargs={'event': 'PLAYER_KILL', 'N': 1},
                   reward_to='team'),
       ts.TaskSpec(eval_fn=bp.CountEvent, eval_fn_kwargs={'event': 'PLAYER_KILL', 'N': 2},
@@ -243,7 +225,7 @@ class TestDemoTask(unittest.TestCase):
     ]
 
     # NOTE: len(teams) and len(task_spec) don't need to match
-    teams = {0:[1,2,3], 1:[4,5], 2:[6,7], 3:[8,9], 4:[10,11]}
+    teams = {1:[1,2,3], 3:[4,5], 6:[6,7], 9:[8,9], 14:[10,11]}
 
     config = ScriptedAgentTestConfig()
     env = Env(config)

--- a/tests/task/test_task_api.py
+++ b/tests/task/test_task_api.py
@@ -233,7 +233,8 @@ class TestTaskAPI(unittest.TestCase):
                          reward_to='team')
 
     # create the test task from the task spec
-    teams = {0:[1,2,3], 1:[4,5], 2:[6,7], 3:[8,9], 4:[10,11]}
+    teams = {1:[1,2,3], 3:[4,5], 6:[6,7], 9:[8,9], 14:[10,11]}
+    team_ids= list(teams.keys())
 
     config = ScriptedAgentTestConfig()
     config.PLAYERS =[Sleeper]
@@ -252,9 +253,9 @@ class TestTaskAPI(unittest.TestCase):
                      'return AllMembersWithinRange(gs, subject, dist) * '+
                      'TickGE(gs, subject, num_tick)')
     self.assertEqual(task.get_signature(), ['gs', 'subject', 'dist', 'num_tick'])
-    self.assertEqual(task.subject, tuple(teams[0]))
+    self.assertEqual(task.subject, tuple(teams[team_ids[0]]))
     self.assertEqual(task.kwargs, task_spec.eval_fn_kwargs)
-    self.assertEqual(task.assignee, tuple(teams[0]))
+    self.assertEqual(task.assignee, tuple(teams[team_ids[0]]))
 
     # check the agent-task map
     for agent_id, agent_tasks in env.agent_task_map.items():
@@ -296,9 +297,9 @@ class TestTaskAPI(unittest.TestCase):
                      'return AllMembersWithinRange(gs, subject, dist) * '+
                      'TickGE(gs, subject, num_tick)')
     self.assertEqual(task.get_signature(), ['gs', 'subject', 'dist', 'num_tick'])
-    self.assertEqual(task.subject, tuple(teams[0]))
+    self.assertEqual(task.subject, tuple(teams[team_ids[0]]))
     self.assertEqual(task.kwargs, task_spec.eval_fn_kwargs)
-    self.assertEqual(task.assignee, tuple(teams[0]))
+    self.assertEqual(task.assignee, tuple(teams[team_ids[0]]))
     self.assertTrue(np.array_equal(task.embedding, task_embedding))
 
     obs_spec = env.observation_space(1)


### PR DESCRIPTION
* "left_team", "right_team" had a problem with the team ids that are not continuous. 