### PR TITLE
Fixed task embedding type, added curriculum-related vars

### DIFF
--- a/nmmo/core/env.py
+++ b/nmmo/core/env.py
@@ -48,7 +48,7 @@ class Env(ParallelEnv):
     # Default task: rewards 1 each turn agent is alive
     self.tasks = task_api.nmmo_default_task(self.possible_agents)
     self.agent_task_map = None
-    self._dummy_task_embedding = np.zeros(self.config.TASK_EMBED_DIM, dtype=np.float32)
+    self._dummy_task_embedding = np.zeros(self.config.TASK_EMBED_DIM, dtype=np.float16)
 
     # curriculum file path, if provided, should exist
     self.curriculum_file_path = config.CURRICULUM_FILE_PATH
@@ -73,7 +73,9 @@ class Env(ParallelEnv):
       "AgentId": gym.spaces.Discrete(self.config.PLAYER_N+1),
       "Tile": box(self.config.MAP_N_OBS, Tile.State.num_attributes),
       "Entity": box(self.config.PLAYER_N_OBS, Entity.State.num_attributes),
-      "Task": gym.spaces.Box(low=-2**15, high=2**15-1, shape=(self.config.TASK_EMBED_DIM,)),
+      "Task": gym.spaces.Box(low=-2**15, high=2**15-1,
+                             shape=(self.config.TASK_EMBED_DIM,),
+                             dtype=np.float16),
     }
 
     if self.config.ITEM_SYSTEM_ENABLED:

--- a/tests/task/test_task_api.py
+++ b/tests/task/test_task_api.py
@@ -427,7 +427,7 @@ class TestTaskAPI(unittest.TestCase):
     for idx in [0, 1]:
       self.assertEqual(env.tasks[idx]._progress, 0.5) # agent 1 & 2 has enough gold
       self.assertEqual(env.tasks[idx]._max_progress, 0.5)
-      self.assertEqual(env.tasks[idx]._reward_count, 5)
+      self.assertEqual(env.tasks[idx].reward_signal_count, 5)
     self.assertTrue(env.tasks[2]._progress == 0.0) # agent 3 has no gold
     for task in env.tasks:
       self.assertTrue(task.completed is False) # not completed yet
@@ -438,10 +438,11 @@ class TestTaskAPI(unittest.TestCase):
     env.step({})
     self.assertEqual(env.tasks[0]._progress, 0.6) # agent 1 has enough gold
     self.assertEqual(env.tasks[0]._max_progress, 0.6)
-    self.assertEqual(env.tasks[0]._reward_count, 6)
+    self.assertEqual(env.tasks[0].reward_signal_count, 6)
     self.assertEqual(env.tasks[1]._progress, 0) # agent 2 has not enough gold
     self.assertEqual(env.tasks[1]._max_progress, 0.5) # max values are preserved
-    self.assertEqual(env.tasks[1]._reward_count, 5)
+    self.assertEqual(env.tasks[1]._positive_reward_count, 5)
+    self.assertEqual(env.tasks[1].reward_signal_count, 6) # 5 positive + 1 negative
 
     for _ in range(4):
       env.step({})


### PR DESCRIPTION
* Fixed task embedding type, so that the task embedding in gym obs has the correct type as specified in obs_space()
* Added `_completed_tick` to the `Task` class to know when the task has been completed (should be correlated with difficulty)
* Added ` _positive_reward_count` and `_negative_reward_count` to the `Task` class to get the frequency of reward signal