### PR TITLE
Added task progress info, got rid of scripted config SPECIALIZE

### DIFF
--- a/nmmo/core/env.py
+++ b/nmmo/core/env.py
@@ -475,11 +475,12 @@ class Env(ParallelEnv):
     # Compute Rewards and infos
     self.game_state = self._gamestate_generator.generate(self.realm, self.obs)
     for task in self.tasks:
-      task_rewards, task_infos = task.compute_rewards(self.game_state)
-      for agent_id, reward in task_rewards.items():
-        if agent_id in agents:
-          rewards[agent_id] = rewards.get(agent_id,0) + reward
-          infos[agent_id]['task'][task.name] = task_infos[agent_id] # progress
+      if agents.intersection(task.assignee): # evaluate only if the agents are current
+        task_rewards, task_infos = task.compute_rewards(self.game_state)
+        for agent_id, reward in task_rewards.items():
+          if agent_id in agents:
+            rewards[agent_id] = rewards.get(agent_id,0) + reward
+            infos[agent_id]['task'][task.name] = task_infos[agent_id] # include progress, etc
 
     # Make sure the dead agents return the rewards of -1
     for agent_id in self._dead_this_tick:

--- a/nmmo/task/task_api.py
+++ b/nmmo/task/task_api.py
@@ -34,6 +34,7 @@ class Task(ABC):
     self.reset()
 
   def reset(self):
+    self._last_eval_tick = None
     self._progress = 0.0
     self._completed_tick = None
     self._max_progress = 0.0
@@ -86,6 +87,7 @@ class Task(ABC):
     Returns rewards and infos for all agents in subject
     """
     reward = self._map_progress_to_reward(gs) * self._reward_multiplier
+    self._last_eval_tick = gs.current_tick
     self._max_progress = max(self._max_progress, self._progress)
     self._positive_reward_count += int(reward > 0)
     self._negative_reward_count += int(reward < 0)
@@ -139,6 +141,19 @@ class Task(ABC):
       return self._eval_fn.kwargs
     # the function _eval_fn must only take gs
     return {}
+
+  @property
+  def progress_info(self):
+    return {
+      "task_spec_name": self.spec_name,
+      "last_eval_tick": self._last_eval_tick,
+      "completed": self.completed,
+      "completed_tick": self._completed_tick,
+      "max_progress": self._max_progress,
+      "positive_reward_count": self._positive_reward_count,
+      "negative_reward_count": self._negative_reward_count,
+      "reward_signal_count": self.reward_signal_count,
+    }
 
 class OngoingTask(Task):
   def _map_progress_to_reward(self, gs: GameState) -> float:

--- a/scripted/baselines.py
+++ b/scripted/baselines.py
@@ -464,42 +464,42 @@ class Gather(Scripted):
 class Fisher(Gather):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.PROFESSION_SYSTEM_ENABLED:
       self.resource = [material.Fish]
     self.tool     = item_system.Rod
 
 class Herbalist(Gather):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.PROFESSION_SYSTEM_ENABLED:
       self.resource = [material.Herb]
     self.tool     = item_system.Gloves
 
 class Prospector(Gather):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.PROFESSION_SYSTEM_ENABLED:
       self.resource = [material.Ore]
     self.tool     = item_system.Pickaxe
 
 class Carver(Gather):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.PROFESSION_SYSTEM_ENABLED:
       self.resource = [material.Tree]
     self.tool     = item_system.Axe
 
 class Alchemist(Gather):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.PROFESSION_SYSTEM_ENABLED:
       self.resource = [material.Crystal]
     self.tool     = item_system.Chisel
 
 class Melee(Combat):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.COMBAT_SYSTEM_ENABLED:
       self.style  = [action.Melee]
     self.weapon = item_system.Spear
     self.ammo   = item_system.Whetstone
@@ -507,7 +507,7 @@ class Melee(Combat):
 class Range(Combat):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.COMBAT_SYSTEM_ENABLED:
       self.style  = [action.Range]
     self.weapon = item_system.Bow
     self.ammo   = item_system.Arrow
@@ -515,7 +515,7 @@ class Range(Combat):
 class Mage(Combat):
   def __init__(self, config, idx):
     super().__init__(config, idx)
-    if config.SPECIALIZE:
+    if config.COMBAT_SYSTEM_ENABLED:
       self.style  = [action.Mage]
     self.weapon = item_system.Wand
     self.ammo   = item_system.Runes

--- a/tests/core/test_env.py
+++ b/tests/core/test_env.py
@@ -21,7 +21,6 @@ TEST_HORIZON = 30
 RANDOM_SEED = random.randint(0, 10000)
 
 class Config(nmmo.config.Small, nmmo.config.AllGameSystems):
-  SPECIALIZE = True
   PLAYERS = [
     baselines.Fisher, baselines.Herbalist, baselines.Prospector,
     baselines.Carver, baselines.Alchemist,

--- a/tests/testhelpers.py
+++ b/tests/testhelpers.py
@@ -119,7 +119,6 @@ class ScriptedAgentTestConfig(nmmo.config.Small, nmmo.config.AllGameSystems):
 
   PLAYER_DEATH_FOG = 5
 
-  SPECIALIZE = True
   PLAYERS = [
     baselines.Fisher, baselines.Herbalist,
     baselines.Prospector,baselines.Carver, baselines.Alchemist,


### PR DESCRIPTION
* `env.py`: evaluate task only when all the task assignees are current (i.e., included in `env.agents`)
* `task_api.py`: the Task class property `progress_info` returns the progress/reward related info as a dictionary
* removed the `SPECIALIZE` config for the scripted agents, which is NOT defined in the `config.py`