### PR TITLE
Env fixes for reward shaping

### DIFF
--- a/nmmo/core/action.py
+++ b/nmmo/core/action.py
@@ -134,12 +134,13 @@ class Move(Node):
     realm.map.tiles[r_new, c_new].add_entity(entity)
 
     # exploration record keeping. moved from entity.py, History.update()
-    dist_from_spawn = utils.linf_single(entity.spawn_pos, (r_new, c_new))
-    if dist_from_spawn > entity.history.exploration:
-      entity.history.exploration = dist_from_spawn
+    progress_to_center = realm.map.dist_border_center -\
+      utils.linf_single(realm.map.center_coord, (r_new, c_new))
+    if progress_to_center > entity.history.exploration:
+      entity.history.exploration = progress_to_center
       if entity.is_player:
         realm.event_log.record(EventCode.GO_FARTHEST, entity,
-                               distance=dist_from_spawn)
+                               distance=progress_to_center)
 
     # CHECK ME: material.Impassible includes void, so this line is not reachable
     #   Does this belong to Entity/Player.update()?

--- a/nmmo/core/action.py
+++ b/nmmo/core/action.py
@@ -239,7 +239,7 @@ class Attack(Node):
     # Testing a spawn immunity against old agents to avoid spawn camping
     immunity = config.COMBAT_SPAWN_IMMUNITY
     if entity.is_player and target.is_player and \
-      target.history.time_alive < immunity < entity.history.time_alive.val:
+      target.history.time_alive < immunity:
       return None
 
     #Check if self targeted

--- a/nmmo/core/config.py
+++ b/nmmo/core/config.py
@@ -437,19 +437,19 @@ class Progression:
   PROGRESSION_LEVEL_MAX             = 10
   '''Max skill level'''
 
-  PROGRESSION_MELEE_BASE_DAMAGE     = 0
+  PROGRESSION_MELEE_BASE_DAMAGE     = 15
   '''Base Melee attack damage'''
 
   PROGRESSION_MELEE_LEVEL_DAMAGE    = 5
   '''Bonus Melee attack damage per level'''
 
-  PROGRESSION_RANGE_BASE_DAMAGE     = 0
+  PROGRESSION_RANGE_BASE_DAMAGE     = 15
   '''Base Range attack damage'''
 
   PROGRESSION_RANGE_LEVEL_DAMAGE    = 5
   '''Bonus Range attack damage per level'''
 
-  PROGRESSION_MAGE_BASE_DAMAGE      = 0
+  PROGRESSION_MAGE_BASE_DAMAGE      = 15
   '''Base Mage attack damage '''
 
   PROGRESSION_MAGE_LEVEL_DAMAGE     = 5

--- a/nmmo/core/config.py
+++ b/nmmo/core/config.py
@@ -437,19 +437,19 @@ class Progression:
   PROGRESSION_LEVEL_MAX             = 10
   '''Max skill level'''
 
-  PROGRESSION_MELEE_BASE_DAMAGE     = 15
+  PROGRESSION_MELEE_BASE_DAMAGE     = 10
   '''Base Melee attack damage'''
 
   PROGRESSION_MELEE_LEVEL_DAMAGE    = 5
   '''Bonus Melee attack damage per level'''
 
-  PROGRESSION_RANGE_BASE_DAMAGE     = 15
+  PROGRESSION_RANGE_BASE_DAMAGE     = 10
   '''Base Range attack damage'''
 
   PROGRESSION_RANGE_LEVEL_DAMAGE    = 5
   '''Bonus Range attack damage per level'''
 
-  PROGRESSION_MAGE_BASE_DAMAGE      = 15
+  PROGRESSION_MAGE_BASE_DAMAGE      = 10
   '''Base Mage attack damage '''
 
   PROGRESSION_MAGE_LEVEL_DAMAGE     = 5

--- a/nmmo/core/map.py
+++ b/nmmo/core/map.py
@@ -27,6 +27,10 @@ class Map:
       for c in range(sz):
         self.tiles[r, c] = Tile(realm, r, c, np_random)
 
+    self.dist_border_center = config.MAP_CENTER // 2
+    self.center_coord = (config.MAP_BORDER + self.dist_border_center,
+                         config.MAP_BORDER + self.dist_border_center)
+
   @property
   def packet(self):
     '''Packet of degenerate resource states'''

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -243,17 +243,16 @@ class Observation:
       ) <= self.config.COMBAT_MELEE_REACH
 
     immunity = self.config.COMBAT_SPAWN_IMMUNITY
-    if 0 < immunity < agent.time_alive:
-      # ids > 0 equals entity.is_player
-      spawn_immunity = (self.entities.ids > 0) & \
-        (self.entities.values[:,EntityState.State.attr_name_to_col["time_alive"]] < immunity)
+    if agent.time_alive < immunity:
+      # NOTE: CANNOT attack players during immunity, thus mask should set to 0
+      no_spawn_immunity = ~(self.entities.ids > 0)  # ids > 0 equals entity.is_player
     else:
-      spawn_immunity = np.ones(self.entities.len, dtype=bool)
+      no_spawn_immunity = np.ones(self.entities.len, dtype=bool)
 
     # allow friendly fire but no self shooting
     not_me = self.entities.ids != agent.id
 
-    attack_mask[:self.entities.len] = within_range & not_me & spawn_immunity
+    attack_mask[:self.entities.len] = within_range & not_me & no_spawn_immunity
     return attack_mask
 
   def _make_use_mask(self):

--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -124,8 +124,10 @@ class Resources:
 
     self.health_restore = 0  # for "healing" bonus
     if food_thresh and water_thresh:
-      self.health_restore = np.floor(self.health.max * regen)
-      self.health.increment(self.health_restore)
+      self.health_restore = -self.health.val  # before incrementing
+      restore = np.floor(self.health.max * regen)
+      self.health.increment(restore)
+      self.health_restore += self.health.val  # after incrementing
 
     if self.food.empty:
       self.health.decrement(self.config.RESOURCE_STARVATION_RATE)

--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -105,6 +105,7 @@ class Resources:
     self.health = ent.health
     self.water = ent.water
     self.food = ent.food
+    self.health_restore = 0
 
     self.health.update(config.PLAYER_BASE_HEALTH)
     if config.RESOURCE_SYSTEM_ENABLED:
@@ -121,9 +122,10 @@ class Resources:
     food_thresh = self.food > thresh * self.config.RESOURCE_BASE
     water_thresh = self.water > thresh * self.config.RESOURCE_BASE
 
+    self.health_restore = 0  # for "healing" bonus
     if food_thresh and water_thresh:
-      restore = np.floor(self.health.max * regen)
-      self.health.increment(restore)
+      self.health_restore = np.floor(self.health.max * regen)
+      self.health.increment(self.health_restore)
 
     if self.food.empty:
       self.health.decrement(self.config.RESOURCE_STARVATION_RATE)

--- a/nmmo/entity/entity.py
+++ b/nmmo/entity/entity.py
@@ -122,18 +122,19 @@ class Resources:
     food_thresh = self.food > thresh * self.config.RESOURCE_BASE
     water_thresh = self.water > thresh * self.config.RESOURCE_BASE
 
-    self.health_restore = 0  # for "healing" bonus
+    org_health = self.health.val
     if food_thresh and water_thresh:
-      self.health_restore = -self.health.val  # before incrementing
       restore = np.floor(self.health.max * regen)
       self.health.increment(restore)
-      self.health_restore += self.health.val  # after incrementing
 
     if self.food.empty:
       self.health.decrement(self.config.RESOURCE_STARVATION_RATE)
 
     if self.water.empty:
       self.health.decrement(self.config.RESOURCE_DEHYDRATION_RATE)
+
+    # records both increase and decrease in health due to food and water
+    self.health_restore = self.health.val - org_health
 
   def packet(self):
     data = {}

--- a/tests/testhelpers.py
+++ b/tests/testhelpers.py
@@ -225,9 +225,14 @@ class ScriptedTestTemplate(unittest.TestCase):
 
     return item_sig
 
-  def _setup_env(self, random_seed, check_assert=True):
+  def _setup_env(self, random_seed, check_assert=True, remove_immunity=False):
     """ set up a new env and perform initial checks """
-    env = ScriptedAgentTestEnv(self.config, seed=random_seed)
+    config = deepcopy(self.config)
+
+    if remove_immunity:
+      config.COMBAT_SPAWN_IMMUNITY = 0
+
+    env = ScriptedAgentTestEnv(config, seed=random_seed)
     env.reset()
 
     # provide money for all


### PR DESCRIPTION
* Increased agent's based damages
* Fixed spawn immunity bug, and added test
* Added the `health_restore` var to mark whether agent's health has been changed due to food and water, which can be easily used as a reward scheme
* Changed the exploration metric, from the distance from spawn position to the progress toward the map center.