### PR TITLE
Some tweaks on the Action Targets

### DIFF
--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -220,7 +220,6 @@ class Observation:
     mask = np.array([self.tile(*d.delta).material_id in material.Habitable.indices
                      for d in action.Direction.edges], dtype=np.int8)
 
-    # To prevent entropy collapse, do NOT allow no-op action
     if sum(mask) <= 1:
       # if only the stay (no-op) is possible, then allow all actions
       mask[:] = 1
@@ -261,14 +260,10 @@ class Observation:
     not_me = self.entities.ids != agent.id
 
     attack_mask[:self.entities.len] = within_range & not_me & no_spawn_immunity
-
-    # To prevent entropy collapse, allow agents to issue random give actions during early training
-    if sum(attack_mask[:self.entities.len]) == 0:
-      attack_mask[self.config.PLAYER_N_OBS//2:] = 1
-
-    # Mask the no-op option, since there should be at least one allowed move
-    # NOTE: this will make agents always attack if there is a valid target
-    attack_mask[-1] = 0
+    if sum(attack_mask[:self.entities.len]) > 0:
+      # Mask the no-op option, since there should be at least one allowed move
+      # NOTE: this will make agents always attack if there is a valid target
+      attack_mask[-1] = 0
 
     return attack_mask
 

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -361,6 +361,11 @@ class Observation:
     player = (self.entities.values[:,EntityState.State.attr_name_to_col["npc_type"]] == 0)
 
     give_mask[:self.entities.len] = same_tile & player & not_me
+
+    # To prevent entropy collapse, allow agents to issue random give actions during early training
+    if sum(give_mask[:self.entities.len]) == 0:
+      give_mask[self.config.PLAYER_N_OBS//2:] = 1
+
     return give_mask
 
   def _make_give_gold_mask(self):

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -326,11 +326,9 @@ class Observation:
     if self.config.PROVIDE_NOOP_ACTION_TARGET:
       give_mask[-1] = 1
 
-    if not self.config.ITEM_SYSTEM_ENABLED or self.dummy_obs or self.agent_in_combat:
-      return give_mask
-
     # To prevent entropy collapse, allow agents to issue random give actions during early training
-    if self.inventory.len == 0:
+    if not self.config.ITEM_SYSTEM_ENABLED or self.dummy_obs or self.agent_in_combat\
+       or self.inventory.len == 0:
       give_mask[self.config.PLAYER_N_OBS//2:] = 1
       return give_mask
 
@@ -342,6 +340,11 @@ class Observation:
     player = (self.entities.values[:,EntityState.State.attr_name_to_col["npc_type"]] == 0)
 
     give_mask[:self.entities.len] = same_tile & player & not_me
+
+    # To prevent entropy collapse, allow agents to issue random give actions during early training
+    if sum(give_mask[:self.entities.len]) == 0:
+      give_mask[self.config.PLAYER_N_OBS//2:] = 1
+
     return give_mask
 
   def _make_give_gold_target_mask(self):

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -219,9 +219,9 @@ class Observation:
     # pylint: disable=not-an-iterable
     mask = np.array([self.tile(*d.delta).material_id in material.Habitable.indices
                      for d in action.Direction.edges], dtype=np.int8)
-    if sum(mask) == 1:  # only the stay is available
+    if sum(mask) == 1:  # only the stay (no-op) is available
       mask[:] = 1
-      mask[-1] = 0  # do not allow noop action
+      mask[-1] = 0  # do not allow no-op action
 
     return mask
 
@@ -261,7 +261,7 @@ class Observation:
     # To prevent entropy collapse, allow agents to issue random give actions during early training
     if sum(attack_mask[:self.entities.len]) == 0:
       attack_mask[self.config.PLAYER_N_OBS//2:] = 1
-      attack_mask[-1] = 0  # do not allow noop action in this case
+      attack_mask[-1] = 0  # do not allow no-op action in this case
 
     return attack_mask
 
@@ -338,10 +338,8 @@ class Observation:
     if self.config.PROVIDE_NOOP_ACTION_TARGET:
       give_mask[-1] = 1
 
-    # To prevent entropy collapse, allow agents to issue random give actions during early training
     if not self.config.ITEM_SYSTEM_ENABLED or self.dummy_obs or self.agent_in_combat\
        or self.inventory.len == 0:
-      give_mask[self.config.PLAYER_N_OBS//2:] = 1
       return give_mask
 
     agent = self.agent()
@@ -352,11 +350,6 @@ class Observation:
     player = (self.entities.values[:,EntityState.State.attr_name_to_col["npc_type"]] == 0)
 
     give_mask[:self.entities.len] = same_tile & player & not_me
-
-    # To prevent entropy collapse, allow agents to issue random give actions during early training
-    if sum(give_mask[:self.entities.len]) == 0:
-      give_mask[self.config.PLAYER_N_OBS//2:] = 1
-
     return give_mask
 
   def _make_give_gold_target_mask(self):
@@ -364,10 +357,8 @@ class Observation:
     if self.config.PROVIDE_NOOP_ACTION_TARGET:
       give_mask[-1] = 1
 
-    # To prevent entropy collapse, allow agents to issue random give actions during early training
     if not self.config.EXCHANGE_SYSTEM_ENABLED or self.dummy_obs or self.agent_in_combat\
        or int(self.agent().gold) == 0:
-      give_mask[self.config.PLAYER_N_OBS//2:] = 1
       return give_mask
 
     agent = self.agent()
@@ -378,24 +369,16 @@ class Observation:
     player = (self.entities.values[:,EntityState.State.attr_name_to_col["npc_type"]] == 0)
 
     give_mask[:self.entities.len] = same_tile & player & not_me
-
-    # To prevent entropy collapse, allow agents to issue random give actions during early training
-    if sum(give_mask[:self.entities.len]) == 0:
-      give_mask[self.config.PLAYER_N_OBS//2:] = 1
-
     return give_mask
 
   def _make_give_gold_mask(self):
     mask = np.zeros(self.config.PRICE_N_OBS, dtype=np.int8)
     mask[0] = 1  # To avoid all-0 masks. If the agent has no gold, this action will be ignored.
     if self.dummy_obs or self.agent_in_combat:
-      # To prevent entropy collapse, allow agents to issue random give actions during early training
-      mask[:] = 1
       return mask
 
     gold = int(self.agent().gold)
     mask[:gold] = 1 # NOTE that action.Price starts from Discrete_1
-
     return mask
 
   def _make_sell_mask(self):
@@ -419,11 +402,8 @@ class Observation:
     if self.config.PROVIDE_NOOP_ACTION_TARGET:
       buy_mask[-1] = 1
 
-    # To prevent entropy collapse, allow agents to issue random buy actions during early training
     if not self.config.EXCHANGE_SYSTEM_ENABLED or self.dummy_obs or self.agent_in_combat \
        or self.market.len == 0:
-      buy_mask[self.config.MARKET_N_OBS//2:] = 1
-      buy_mask[-1] = 0  # do not allow noop action in this case
       return buy_mask
 
     agent = self.agent()
@@ -440,12 +420,6 @@ class Observation:
 
     enough_gold = market_items[:,ItemState.State.attr_name_to_col["listed_price"]] <= agent.gold
     buy_mask[:self.market.len] = not_mine & enough_gold
-
-    # To prevent entropy collapse, allow agents to issue random give actions during early training
-    if sum(buy_mask[:self.market.len]) == 0:
-      buy_mask[self.config.MARKET_N_OBS//2:] = 1
-      buy_mask[-1] = 0  # do not allow noop action in this case
-
     return buy_mask
 
   def _existing_ammo_listings(self):

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -215,9 +215,15 @@ class Observation:
       mask = np.zeros(len(action.Direction.edges), dtype=np.int8)
       mask[-1] = 1  # make sure the noop action is available
       return mask
+
     # pylint: disable=not-an-iterable
-    return np.array([self.tile(*d.delta).material_id in material.Habitable.indices
+    mask = np.array([self.tile(*d.delta).material_id in material.Habitable.indices
                      for d in action.Direction.edges], dtype=np.int8)
+    if sum(mask) == 1:  # only the stay is available
+      mask[:] = 1
+      mask[-1] = 0  # do not allow noop action
+
+    return mask
 
   def _make_attack_mask(self):
     # NOTE: Currently, all attacks have the same range

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -434,6 +434,12 @@ class Observation:
 
     enough_gold = market_items[:,ItemState.State.attr_name_to_col["listed_price"]] <= agent.gold
     buy_mask[:self.market.len] = not_mine & enough_gold
+
+    # To prevent entropy collapse, allow agents to issue random give actions during early training
+    if sum(buy_mask[:self.market.len]) == 0:
+      buy_mask[self.config.MARKET_N_OBS//2:] = 1
+      buy_mask[-1] = 0  # do not allow noop action in this case
+
     return buy_mask
 
   def _existing_ammo_listings(self):

--- a/nmmo/core/observation.py
+++ b/nmmo/core/observation.py
@@ -251,6 +251,12 @@ class Observation:
     not_me = self.entities.ids != agent.id
 
     attack_mask[:self.entities.len] = within_range & not_me & no_spawn_immunity
+
+    # To prevent entropy collapse, allow agents to issue random give actions during early training
+    if sum(attack_mask[:self.entities.len]) == 0:
+      attack_mask[self.config.PLAYER_N_OBS//2:] = 1
+      attack_mask[-1] = 0  # do not allow noop action in this case
+
     return attack_mask
 
   def _make_use_mask(self):
@@ -411,6 +417,7 @@ class Observation:
     if not self.config.EXCHANGE_SYSTEM_ENABLED or self.dummy_obs or self.agent_in_combat \
        or self.market.len == 0:
       buy_mask[self.config.MARKET_N_OBS//2:] = 1
+      buy_mask[-1] = 0  # do not allow noop action in this case
       return buy_mask
 
     agent = self.agent()

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -31,7 +31,7 @@ class TestAmmoUse(ScriptedTestTemplate):
       mask += np.sum(gym_obs["ActionTargets"][atn.__name__]["InventoryItem"])
     # If MarketItem and InventoryTarget have no-action flags, these sum up to 5
     # To prevent entropy collapse, GiveGold/Price and Buy/MarketItem masks are tweaked
-    self.assertEqual(mask, 99 + 511 + 5*int(self.config.PROVIDE_NOOP_ACTION_TARGET))
+    self.assertEqual(mask, 1 + 5*int(self.config.PROVIDE_NOOP_ACTION_TARGET))
 
   def test_spawn_immunity(self):
     env = self._setup_env(random_seed=RANDOM_SEED)

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -31,7 +31,7 @@ class TestAmmoUse(ScriptedTestTemplate):
       mask += np.sum(gym_obs["ActionTargets"][atn.__name__]["InventoryItem"])
     # If MarketItem and InventoryTarget have no-action flags, these sum up to 5
     # To prevent entropy collapse, GiveGold/Price and Buy/MarketItem masks are tweaked
-    self.assertEqual(mask, 99 + 512 + 5*int(self.config.PROVIDE_NOOP_ACTION_TARGET))
+    self.assertEqual(mask, 99 + 511 + 5*int(self.config.PROVIDE_NOOP_ACTION_TARGET))
 
   def test_spawn_immunity(self):
     env = self._setup_env(random_seed=RANDOM_SEED)

--- a/tests/action/test_ammo_use.py
+++ b/tests/action/test_ammo_use.py
@@ -30,7 +30,8 @@ class TestAmmoUse(ScriptedTestTemplate):
     for atn in [action.Use, action.Give, action.Destroy, action.Sell]:
       mask += np.sum(gym_obs["ActionTargets"][atn.__name__]["InventoryItem"])
     # If MarketItem and InventoryTarget have no-action flags, these sum up to 5
-    self.assertEqual(mask, 1 + 5*int(self.config.PROVIDE_NOOP_ACTION_TARGET))
+    # To prevent entropy collapse, GiveGold/Price and Buy/MarketItem masks are tweaked
+    self.assertEqual(mask, 99 + 512 + 5*int(self.config.PROVIDE_NOOP_ACTION_TARGET))
 
   def test_spawn_immunity(self):
     env = self._setup_env(random_seed=RANDOM_SEED)


### PR DESCRIPTION
Various attempts to prevent entropy collapse in puffer 0.4, but not successful. However, the end result works well with puffer 0.3, making the agent run faster in the early phase.

The change was to provide NO no-op option at all to the Move and Attack actions. In some cases, policies returned no-ops for Move and Attack event when there were valid options, resulting in starvation and/or score collapse). With the new mask, this does not happen. 
